### PR TITLE
LFO rework

### DIFF
--- a/public/lib/p5.gui.js
+++ b/public/lib/p5.gui.js
@@ -160,6 +160,12 @@
     this.toggleVisibility = function () {
       qs.toggleVisibility();
     };
+    this.collapse = function () {
+      qs.collapse();
+    };
+    this.expand = function () {
+      qs.expand();
+    };
     this.setPosition = function (x, y) {
       qs.setPosition(x, y);
       return this;

--- a/public/lib/p5.gui.js
+++ b/public/lib/p5.gui.js
@@ -52,10 +52,13 @@
         console.log("Creating p5.gui powered by QuickSettings.");
         gui = new QSGui(label, parent, sketch);
 
-        const uiPanel = document.querySelector(".qs_main");
-        uiPanel.addEventListener("mousedown", (e) => {
-          // prevent mouse events passing through the UI and into the canvas
-          e.stopPropagation();
+        const uiPanels = document.querySelectorAll(".qs_main");
+
+        uiPanels.forEach((panel) => {
+          panel.addEventListener("mousedown", (e) => {
+            // prevent mouse events passing through the UI and into the canvas
+            e.stopPropagation();
+          });
         });
       } else {
         console.log(

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -14,6 +14,10 @@ const app = (s) => {
     const gui = s.createGui("paintbrush options", this);
     gui.addObject(state.gui);
 
+    const lfoGui = s.createGui("lfo options", this);
+    lfoGui.setPosition(s.windowWidth - 240, 20);
+    lfoGui.addObject(state.lfo);
+
     socket.on("update", (paintProperties) => {
       updateDrawing(s, paintProperties);
     });

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -21,6 +21,12 @@ const app = (s) => {
     const lfo2Gui = s.createGui("lfo2", this);
     lfo2Gui.setPosition(s.windowWidth - 240, 380);
     lfo2Gui.addObject(state.lfo2.gui);
+    lfo2Gui.collapse();
+
+    const lfo3Gui = s.createGui("lfo3", this);
+    lfo3Gui.setPosition(s.windowWidth - 240, 420);
+    lfo3Gui.addObject(state.lfo3.gui);
+    lfo3Gui.collapse();
 
     socket.on("update", (paintProperties) => {
       updateDrawing(s, paintProperties);

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -11,12 +11,16 @@ const app = (s) => {
     s.background(0);
     s.rectMode(s.CENTER);
 
-    const gui = s.createGui("paintbrush options", this);
+    const gui = s.createGui("paintbrush", this);
     gui.addObject(state.gui);
 
-    const lfoGui = s.createGui("lfo options", this);
-    lfoGui.setPosition(s.windowWidth - 240, 20);
-    lfoGui.addObject(state.lfo);
+    const lfo1Gui = s.createGui("lfo1", this);
+    lfo1Gui.setPosition(s.windowWidth - 240, 20);
+    lfo1Gui.addObject(state.lfo1.gui);
+
+    const lfo2Gui = s.createGui("lfo2", this);
+    lfo2Gui.setPosition(s.windowWidth - 240, 380);
+    lfo2Gui.addObject(state.lfo2.gui);
 
     socket.on("update", (paintProperties) => {
       updateDrawing(s, paintProperties);

--- a/public/src/constants.js
+++ b/public/src/constants.js
@@ -1,1 +1,12 @@
 export const dimensions = { width: 1920, height: 1000 };
+
+export const paintProperties = {
+  FILL_COLOR: "fillColor",
+  STROKE_COLOR: "strokeColor",
+  FILL_OPACITY: "fillOpacity",
+  STROKE_OPACITY: "strokeOpacity",
+  SIZE: "size",
+  SHAPE: "shape",
+  MIRROR_X: "mirrorX",
+  MIRROR_Y: "mirrorY",
+};

--- a/public/src/initialState.js
+++ b/public/src/initialState.js
@@ -9,21 +9,6 @@ const guiParams = {
   shape: ["circle", "square"],
   mirrorX: false,
   mirrorY: false,
-  isRainbowFill: false,
-  isRainbowStroke: false,
-  rainbowSpeed: 0.5,
-  rainbowSpeedMin: 0,
-  rainbowSpeedMax: 1,
-  rainbowSpeedStep: 0.01,
-  isSizeOscillating: false,
-  sizeOscSpeed: 0.001,
-  sizeOscSpeedMin: 0,
-  sizeOscSpeedMax: 0.2,
-  sizeOscSpeedStep: 0.001,
-  sizeOscAmount: 1,
-  sizeOscAmountMin: 0,
-  sizeOscAmountMax: 100,
-  sizeOscAmountStep: 0.01,
 };
 
 const lfoControllableParams = [
@@ -52,7 +37,6 @@ lfoControllableParams.forEach((param) => (lfoParams[param] = false));
 export const state = {
   gui: guiParams,
   lfo: lfoParams,
-  rainbowCounter: 0,
   sizeOsc: 0,
   lfoValue: 0,
 };

--- a/public/src/initialState.js
+++ b/public/src/initialState.js
@@ -20,11 +20,11 @@ const lfoControllableParams = [
 ];
 
 const lfoParams = {
-  speed: 0.001,
-  speedMin: 0,
-  speedMax: 0.2,
-  speedStep: 0.001,
-  amount: 1,
+  speed: 0.00005,
+  speedMin: 0.00001,
+  speedMax: 0.5,
+  speedStep: 0.00001,
+  amount: 50,
   amountMin: 0,
   amountMax: 100,
   amountStep: 0.01,

--- a/public/src/initialState.js
+++ b/public/src/initialState.js
@@ -26,8 +26,27 @@ const guiParams = {
   sizeOscAmountStep: 0.01,
 };
 
+const lfoControllableParams = ["fillOpacity", "strokeOpacity", "size"];
+
+const lfoParams = {
+  speed: 0.001,
+  speedMin: 0,
+  speedMax: 0.2,
+  speedStep: 0.001,
+  amount: 1,
+  amountMin: 0,
+  amountMax: 100,
+  amountStep: 0.01,
+  shape: ["sine", "triangle", "square", "saw", "random"],
+};
+
+// add toggle controls for each available LFO target
+lfoControllableParams.forEach((param) => (lfoParams[param] = false));
+
 export const state = {
   gui: guiParams,
+  lfo: lfoParams,
   rainbowCounter: 0,
   sizeOsc: 0,
+  lfoValue: 0,
 };

--- a/public/src/initialState.js
+++ b/public/src/initialState.js
@@ -15,8 +15,8 @@ const lfoControllableParams = [
   "fillOpacity",
   "strokeOpacity",
   "size",
-  "fill",
-  "stroke",
+  "fillColor",
+  "strokeColor",
 ];
 
 const lfoParams = {
@@ -36,7 +36,6 @@ lfoControllableParams.forEach((param) => (lfoParams[param] = false));
 
 export const state = {
   gui: guiParams,
-  lfo: lfoParams,
-  sizeOsc: 0,
-  lfoValue: 0,
+  lfo1: { gui: { ...lfoParams }, value: 0 },
+  lfo2: { gui: { ...lfoParams }, value: 0 },
 };

--- a/public/src/initialState.js
+++ b/public/src/initialState.js
@@ -38,4 +38,5 @@ export const state = {
   gui: guiParams,
   lfo1: { gui: { ...lfoParams }, value: 0 },
   lfo2: { gui: { ...lfoParams }, value: 0 },
+  lfo3: { gui: { ...lfoParams }, value: 0 },
 };

--- a/public/src/initialState.js
+++ b/public/src/initialState.js
@@ -26,7 +26,13 @@ const guiParams = {
   sizeOscAmountStep: 0.01,
 };
 
-const lfoControllableParams = ["fillOpacity", "strokeOpacity", "size"];
+const lfoControllableParams = [
+  "fillOpacity",
+  "strokeOpacity",
+  "size",
+  "fill",
+  "stroke",
+];
 
 const lfoParams = {
   speed: 0.001,

--- a/public/src/initialState.js
+++ b/public/src/initialState.js
@@ -1,22 +1,24 @@
+import { paintProperties as p } from "./constants.js";
+
 const guiParams = {
-  fillColor: "#349beb",
-  fillOpacity: 255,
-  strokeColor: "#000000",
-  strokeOpacity: 255,
-  size: 15,
+  [p.FILL_COLOR]: "#349beb",
+  [p.FILL_OPACITY]: 255,
+  [p.STROKE_COLOR]: "#000000",
+  [p.STROKE_OPACITY]: 255,
+  [p.SIZE]: 15,
   sizeMin: 5,
   sizeMax: 300,
-  shape: ["circle", "square"],
-  mirrorX: false,
-  mirrorY: false,
+  [p.SHAPE]: ["circle", "square"],
+  [p.MIRROR_X]: false,
+  [p.MIRROR_Y]: false,
 };
 
 const lfoControllableParams = [
-  "fillOpacity",
-  "strokeOpacity",
-  "size",
-  "fillColor",
-  "strokeColor",
+  p.FILL_OPACITY,
+  p.STROKE_OPACITY,
+  p.SIZE,
+  p.FILL_COLOR,
+  p.STROKE_COLOR,
 ];
 
 const lfoParams = {

--- a/public/src/utils/Waveforms.js
+++ b/public/src/utils/Waveforms.js
@@ -1,0 +1,27 @@
+export class Waveforms {
+  static sine(x) {
+    return Math.sin(x);
+  }
+
+  static square(x) {
+    if (x <= Math.PI) {
+      return -1;
+    }
+    return 1;
+  }
+
+  static triangle(x) {
+    if (x <= Math.PI) {
+      return x / (Math.PI * 0.5) - 1;
+    }
+    return (x - Math.PI) / (-Math.PI * 0.5) + 1;
+  }
+
+  static saw(x) {
+    return x / Math.PI - 1;
+  }
+
+  static random() {
+    return Math.random() * 2 - 1;
+  }
+}

--- a/public/src/utils/drawing.js
+++ b/public/src/utils/drawing.js
@@ -7,16 +7,7 @@ export const updateDrawing = (p5, paintProperties) => {
 
 const handleColor = (
   p5,
-  {
-    fillColor,
-    fillOpacity,
-    strokeColor,
-    strokeOpacity,
-    isRainbowFill,
-    isRainbowStroke,
-    rainbowFill,
-    rainbowStroke,
-  }
+  { fillColor, fillOpacity, strokeColor, strokeOpacity }
 ) => {
   const stroke = p5.color(strokeColor);
   stroke.setAlpha(strokeOpacity);
@@ -24,19 +15,8 @@ const handleColor = (
   const fill = p5.color(fillColor);
   fill.setAlpha(fillOpacity);
 
-  if (isRainbowFill && isRainbowStroke) {
-    p5.stroke(rainbowStroke);
-    p5.fill(rainbowFill);
-  } else if (isRainbowFill) {
-    p5.fill(rainbowFill);
-    p5.stroke(stroke);
-  } else if (isRainbowStroke) {
-    p5.fill(fill);
-    p5.stroke(rainbowStroke);
-  } else {
-    p5.stroke(stroke);
-    p5.fill(fill);
-  }
+  p5.stroke(stroke);
+  p5.fill(fill);
 };
 
 const renderShape = (

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -29,6 +29,9 @@ export const useLfo = (p5, state) => {
     fill,
     stroke,
   } = lfo;
+
+  // default to the values from the GUI, if no LFO stuff is enabled, return untouched
+  // if any are enabled, they will be overwritten by their LFO'd values
   const values = {
     fillOpacity: gui.fillOpacity,
     strokeOpacity: gui.strokeOpacity,
@@ -37,8 +40,10 @@ export const useLfo = (p5, state) => {
     stroke: gui.strokeColor,
   };
 
+  // if any of the LFO targetable params are enabled, advance the lfo
   if (fillOpacity || strokeOpacity || size || fill || stroke) {
     state.lfoValue += speed;
+    // up to PI * 2 because geometry
     state.lfoValue %= Math.PI * 2;
   }
 
@@ -77,18 +82,26 @@ export const useLfo = (p5, state) => {
   }
 
   if (size) {
+    // +1 so the oscillation never goes below the minimum/default size set in paintbrush options
     values.size = gui.size + (Waveforms[shape](state.lfoValue) + 1) * amount;
   }
 
   return values;
 };
 
+// this function handles bias/offset from GUI-derived values applied to the LFO
+// note: this function does not work w/ colors, just raw numbers
 const scaleLfoValue = (p5, lfoValue, guiValue, min, max) => {
   return p5.map(lfoValue, -max + guiValue, max + guiValue, min, max);
 };
 
 const useRainbow = (p5, value, opacity) => {
+  // values range from -360 to 360 so we use the absolute value
+  // this makes the colors loop 2x as fast, so that is accounted for by halving the raw LFO value
   const hue = Math.abs(Math.floor(value));
+
+  // TODO: add GUI sliders for these values - the values should override
+  // the default color selection (i.e. even if not using useRainbow) but also effect this function
   const saturation = p5.map(p5.mouseY, 0, p5.windowHeight, 100, 75);
   const brightness = p5.map(p5.mouseY, 0, p5.windowHeight, 100, 50);
 

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -1,14 +1,22 @@
+import { Waveforms } from "./Waveforms.js";
+
 export const setupPaintProperties = (p5, state) => {
-  const { rainbowFill, rainbowStroke } = useRainbow(p5, state);
+  const { size, fillOpacity, strokeOpacity } = useLfo(state);
+  const { rainbowFill, rainbowStroke } = useRainbow(
+    p5,
+    state,
+    fillOpacity,
+    strokeOpacity
+  );
 
   return {
     x: p5.mouseX,
     y: p5.mouseY,
     fillColor: state.gui.fillColor,
-    fillOpacity: state.gui.fillOpacity,
     strokeColor: state.gui.strokeColor,
-    strokeOpacity: state.gui.strokeOpacity,
-    size: modulateSize(p5, state),
+    size,
+    fillOpacity,
+    strokeOpacity,
     shape: state.gui.shape,
     mirrorX: state.gui.mirrorX,
     mirrorY: state.gui.mirrorY,
@@ -17,6 +25,38 @@ export const setupPaintProperties = (p5, state) => {
     rainbowFill: rainbowFill.toString(),
     rainbowStroke: rainbowStroke.toString(),
   };
+};
+
+export const useLfo = (state) => {
+  const { gui, lfo } = state;
+  const { speed, amount, shape, fillOpacity, strokeOpacity, size } = lfo;
+  const values = {
+    fillOpacity: gui.fillOpacity,
+    strokeOpacity: gui.strokeOpacity,
+    size: gui.size,
+  };
+
+  if (fillOpacity || strokeOpacity || size) {
+    state.lfoValue += speed;
+    state.lfoValue %= Math.PI * 2;
+  }
+
+  if (fillOpacity) {
+    // scale color values by 2.55x: 100 * 2.55 = 255
+    values.fillOpacity =
+      gui.fillOpacity + Waveforms[shape](state.lfoValue) * (amount * 2.55);
+  }
+
+  if (strokeOpacity) {
+    values.strokeOpacity =
+      gui.strokeOpacity + Waveforms[shape](state.lfoValue) * (amount * 2.55);
+  }
+
+  if (size) {
+    values.size = gui.size + (Waveforms[shape](state.lfoValue) + 1) * amount;
+  }
+
+  return values;
 };
 
 const modulateSize = (p5, state) => {
@@ -30,7 +70,7 @@ const modulateSize = (p5, state) => {
   return size;
 };
 
-const useRainbow = (p5, state) => {
+const useRainbow = (p5, state, fillOpacity, strokeOpacity) => {
   state.rainbowCounter += 1 * state.gui.rainbowSpeed;
 
   const hue = Math.floor(state.rainbowCounter % 360);
@@ -38,10 +78,10 @@ const useRainbow = (p5, state) => {
   const brightness = p5.map(p5.mouseY, 0, p5.windowHeight, 100, 50);
 
   const rainbowFill = p5.color(`hsb(${hue}, ${saturation}%, ${brightness}%)`);
-  rainbowFill.setAlpha(state.gui.fillOpacity);
+  rainbowFill.setAlpha(Math.ceil(fillOpacity));
 
   const rainbowStroke = p5.color(`hsb(${hue}, ${saturation}%, ${brightness}%)`);
-  rainbowStroke.setAlpha(state.gui.strokeOpacity);
+  rainbowStroke.setAlpha(Math.ceil(strokeOpacity));
 
   return { rainbowFill, rainbowStroke };
 };

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -2,12 +2,6 @@ import { Waveforms } from "./Waveforms.js";
 
 export const setupPaintProperties = (p5, state) => {
   const { size, fillOpacity, strokeOpacity, fill, stroke } = useLfo(p5, state);
-  const { rainbowFill, rainbowStroke } = useRainbow(
-    p5,
-    state,
-    fillOpacity,
-    strokeOpacity
-  );
 
   return {
     x: p5.mouseX,
@@ -20,10 +14,6 @@ export const setupPaintProperties = (p5, state) => {
     shape: state.gui.shape,
     mirrorX: state.gui.mirrorX,
     mirrorY: state.gui.mirrorY,
-    isRainbowFill: state.gui.isRainbowFill,
-    isRainbowStroke: state.gui.isRainbowStroke,
-    rainbowFill: rainbowFill.toString(),
-    rainbowStroke: rainbowStroke.toString(),
   };
 };
 
@@ -67,7 +57,7 @@ export const useLfo = (p5, state) => {
     // scale lfoValue by half because the range is -360 to 360 and we use the absolute value
     // i.e. the rotation speed is 2x other values tracking the LFO, so halve the speed
     const lfoValue = Waveforms[shape](state.lfoValue * 0.5) * (amount * 3.6);
-    const rainbow = newUseRainbow(p5, lfoValue, values.fillOpacity);
+    const rainbow = useRainbow(p5, lfoValue, values.fillOpacity);
     values.fill = rainbow;
   }
 
@@ -82,7 +72,7 @@ export const useLfo = (p5, state) => {
 
   if (stroke) {
     const lfoValue = Waveforms[shape](state.lfoValue * 0.5) * (amount * 3.6);
-    const rainbow = newUseRainbow(p5, lfoValue, values.strokeOpacity);
+    const rainbow = useRainbow(p5, lfoValue, values.strokeOpacity);
     values.stroke = rainbow;
   }
 
@@ -97,7 +87,7 @@ const scaleLfoValue = (p5, lfoValue, guiValue, min, max) => {
   return p5.map(lfoValue, -max + guiValue, max + guiValue, min, max);
 };
 
-const newUseRainbow = (p5, value, opacity) => {
+const useRainbow = (p5, value, opacity) => {
   const hue = Math.abs(Math.floor(value));
   const saturation = p5.map(p5.mouseY, 0, p5.windowHeight, 100, 75);
   const brightness = p5.map(p5.mouseY, 0, p5.windowHeight, 100, 50);
@@ -106,20 +96,4 @@ const newUseRainbow = (p5, value, opacity) => {
   rainbow.setAlpha(Math.ceil(opacity));
 
   return rainbow.toString("#rrggbb");
-};
-
-const useRainbow = (p5, state, fillOpacity, strokeOpacity) => {
-  state.rainbowCounter += 1 * state.gui.rainbowSpeed;
-
-  const hue = Math.floor(state.rainbowCounter % 360);
-  const saturation = p5.map(p5.mouseY, 0, p5.windowHeight, 100, 75);
-  const brightness = p5.map(p5.mouseY, 0, p5.windowHeight, 100, 50);
-
-  const rainbowFill = p5.color(`hsb(${hue}, ${saturation}%, ${brightness}%)`);
-  rainbowFill.setAlpha(Math.ceil(fillOpacity));
-
-  const rainbowStroke = p5.color(`hsb(${hue}, ${saturation}%, ${brightness}%)`);
-  rainbowStroke.setAlpha(Math.ceil(strokeOpacity));
-
-  return { rainbowFill, rainbowStroke };
 };

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -1,20 +1,22 @@
 import { Waveforms } from "./Waveforms.js";
+import { paintProperties as p } from "../constants.js";
 
 export const setupPaintProperties = (p5, state) => {
   const { gui } = state;
   const lfo1 = useLfo(p5, state.gui, state.lfo1);
   const lfo2 = useLfo(p5, state.gui, state.lfo2);
   const lfo3 = useLfo(p5, state.gui, state.lfo3);
+  // pack lfos in reverse order so subsequent LFOs override previous ones
   const lfos = [lfo3, lfo2, lfo1];
 
   return {
     x: p5.mouseX,
     y: p5.mouseY,
-    fillColor: handleLfoValue(lfos, gui, "fillColor"),
-    strokeColor: handleLfoValue(lfos, gui, "strokeColor"),
-    size: handleLfoValue(lfos, gui, "size"),
-    fillOpacity: handleLfoValue(lfos, gui, "fillOpacity"),
-    strokeOpacity: handleLfoValue(lfos, gui, "strokeOpacity"),
+    fillColor: handleLfoValue(lfos, gui, p.FILL_COLOR),
+    strokeColor: handleLfoValue(lfos, gui, p.STROKE_COLOR),
+    size: handleLfoValue(lfos, gui, p.SIZE),
+    fillOpacity: handleLfoValue(lfos, gui, p.FILL_OPACITY),
+    strokeOpacity: handleLfoValue(lfos, gui, p.STROKE_OPACITY),
     shape: gui.shape,
     mirrorX: gui.mirrorX,
     mirrorY: gui.mirrorY,
@@ -59,7 +61,7 @@ export const useLfo = (p5, gui, lfo) => {
 
     const scaledValue = scaleLfoValue(p5, lfoValue, gui.fillOpacity, 0, 255);
 
-    values.fillOpacity = scaledValue;
+    values[p.FILL_OPACITY] = scaledValue;
   }
 
   if (fillColor) {
@@ -68,7 +70,7 @@ export const useLfo = (p5, gui, lfo) => {
     // i.e. the rotation speed is 2x other values tracking the LFO, so halve the speed
     const lfoValue = Waveforms[shape](lfo.value * 0.5) * (amount * 3.6);
     const rainbow = useRainbow(p5, lfoValue, values.fillOpacity);
-    values.fillColor = rainbow;
+    values[p.FILL_COLOR] = rainbow;
   }
 
   if (strokeOpacity) {
@@ -83,12 +85,12 @@ export const useLfo = (p5, gui, lfo) => {
   if (strokeColor) {
     const lfoValue = Waveforms[shape](lfo.value * 0.5) * (amount * 3.6);
     const rainbow = useRainbow(p5, lfoValue, values.strokeOpacity);
-    values.strokeColor = rainbow;
+    values[p.STROKE_COLOR] = rainbow;
   }
 
   if (size) {
     // +1 so the oscillation never goes below the minimum/default size set in paintbrush options
-    values.size = gui.size + (Waveforms[shape](lfo.value) + 1) * amount;
+    values[p.SIZE] = gui.size + (Waveforms[shape](lfo.value) + 1) * amount;
   }
 
   return values;

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -1,7 +1,7 @@
 import { Waveforms } from "./Waveforms.js";
 
 export const setupPaintProperties = (p5, state) => {
-  const { size, fillOpacity, strokeOpacity } = useLfo(state);
+  const { size, fillOpacity, strokeOpacity } = useLfo(p5, state);
   const { rainbowFill, rainbowStroke } = useRainbow(
     p5,
     state,
@@ -27,7 +27,7 @@ export const setupPaintProperties = (p5, state) => {
   };
 };
 
-export const useLfo = (state) => {
+export const useLfo = (p5, state) => {
   const { gui, lfo } = state;
   const { speed, amount, shape, fillOpacity, strokeOpacity, size } = lfo;
   const values = {
@@ -43,13 +43,21 @@ export const useLfo = (state) => {
 
   if (fillOpacity) {
     // scale color values by 2.55x: 100 * 2.55 = 255
-    values.fillOpacity =
+    const lfoValue =
       gui.fillOpacity + Waveforms[shape](state.lfoValue) * (amount * 2.55);
+
+    const scaledValue = scaleLfoValue(p5, lfoValue, gui.fillOpacity, 0, 255);
+
+    values.fillOpacity = scaledValue;
   }
 
   if (strokeOpacity) {
-    values.strokeOpacity =
+    const lfoValue =
       gui.strokeOpacity + Waveforms[shape](state.lfoValue) * (amount * 2.55);
+
+    const scaledValue = scaleLfoValue(p5, lfoValue, gui.strokeOpacity, 0, 255);
+
+    values.strokeOpacity = scaledValue;
   }
 
   if (size) {
@@ -59,15 +67,8 @@ export const useLfo = (state) => {
   return values;
 };
 
-const modulateSize = (p5, state) => {
-  const { isSizeOscillating, sizeOscSpeed, sizeOscAmount, size } = state.gui;
-
-  if (isSizeOscillating) {
-    state.sizeOsc += sizeOscSpeed;
-    return size + (p5.sin(state.sizeOsc) + 1) * sizeOscAmount;
-  }
-
-  return size;
+const scaleLfoValue = (p5, lfoValue, guiValue, min, max) => {
+  return p5.map(lfoValue, -max + guiValue, max + guiValue, min, max);
 };
 
 const useRainbow = (p5, state, fillOpacity, strokeOpacity) => {

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -4,15 +4,16 @@ export const setupPaintProperties = (p5, state) => {
   const { gui } = state;
   const lfo1 = useLfo(p5, state.gui, state.lfo1);
   const lfo2 = useLfo(p5, state.gui, state.lfo2);
+  const lfo3 = useLfo(p5, state.gui, state.lfo3);
 
   return {
     x: p5.mouseX,
     y: p5.mouseY,
-    fillColor: handleLfoValue(lfo1, lfo2, gui, "fillColor"),
-    strokeColor: handleLfoValue(lfo1, lfo2, gui, "strokeColor"),
-    size: handleLfoValue(lfo1, lfo2, gui, "size"),
-    fillOpacity: handleLfoValue(lfo1, lfo2, gui, "fillOpacity"),
-    strokeOpacity: handleLfoValue(lfo1, lfo2, gui, "strokeOpacity"),
+    fillColor: handleLfoValue(lfo1, lfo2, lfo3, gui, "fillColor"),
+    strokeColor: handleLfoValue(lfo1, lfo2, lfo3, gui, "strokeColor"),
+    size: handleLfoValue(lfo1, lfo2, lfo3, gui, "size"),
+    fillOpacity: handleLfoValue(lfo1, lfo2, lfo3, gui, "fillOpacity"),
+    strokeOpacity: handleLfoValue(lfo1, lfo2, lfo3, gui, "strokeOpacity"),
     shape: gui.shape,
     mirrorX: gui.mirrorX,
     mirrorY: gui.mirrorY,
@@ -21,7 +22,8 @@ export const setupPaintProperties = (p5, state) => {
 
 // default to the values from the GUI if no LFO stuff is enabled
 // if any are enabled, they will be overwritten by their LFO'd values
-const handleLfoValue = (lfo1, lfo2, gui, value) => {
+const handleLfoValue = (lfo1, lfo2, lfo3, gui, value) => {
+  if (lfo3[value]) return lfo3[value];
   if (lfo2[value]) return lfo2[value];
   if (lfo1[value]) return lfo1[value];
   else return gui[value];

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -5,15 +5,16 @@ export const setupPaintProperties = (p5, state) => {
   const lfo1 = useLfo(p5, state.gui, state.lfo1);
   const lfo2 = useLfo(p5, state.gui, state.lfo2);
   const lfo3 = useLfo(p5, state.gui, state.lfo3);
+  const lfos = [lfo3, lfo2, lfo1];
 
   return {
     x: p5.mouseX,
     y: p5.mouseY,
-    fillColor: handleLfoValue(lfo1, lfo2, lfo3, gui, "fillColor"),
-    strokeColor: handleLfoValue(lfo1, lfo2, lfo3, gui, "strokeColor"),
-    size: handleLfoValue(lfo1, lfo2, lfo3, gui, "size"),
-    fillOpacity: handleLfoValue(lfo1, lfo2, lfo3, gui, "fillOpacity"),
-    strokeOpacity: handleLfoValue(lfo1, lfo2, lfo3, gui, "strokeOpacity"),
+    fillColor: handleLfoValue(lfos, gui, "fillColor"),
+    strokeColor: handleLfoValue(lfos, gui, "strokeColor"),
+    size: handleLfoValue(lfos, gui, "size"),
+    fillOpacity: handleLfoValue(lfos, gui, "fillOpacity"),
+    strokeOpacity: handleLfoValue(lfos, gui, "strokeOpacity"),
     shape: gui.shape,
     mirrorX: gui.mirrorX,
     mirrorY: gui.mirrorY,
@@ -22,11 +23,12 @@ export const setupPaintProperties = (p5, state) => {
 
 // default to the values from the GUI if no LFO stuff is enabled
 // if any are enabled, they will be overwritten by their LFO'd values
-const handleLfoValue = (lfo1, lfo2, lfo3, gui, value) => {
-  if (lfo3[value]) return lfo3[value];
-  if (lfo2[value]) return lfo2[value];
-  if (lfo1[value]) return lfo1[value];
-  else return gui[value];
+const handleLfoValue = (lfos, gui, value) => {
+  for (const lfo of lfos) {
+    if (lfo[value]) return lfo[value];
+  }
+
+  return gui[value];
 };
 
 export const useLfo = (p5, gui, lfo) => {


### PR DESCRIPTION
This PR reworks the LFO behavior we had present in the app (for size and color previously). It essentially decouples the LFO behavior from being a property of the underlying parameter, and instead creates separate LFO "modules" that can be mapped to existing parameters - at present those are `fillColor`, `fillOpacity`, `strokeColor`, `strokeOpacity`, and `size`. There are 3 such LFO modules that have controls for setting the frequency, amplitude, and waveform of the LFO (sine, triangle, square, saw, and random). LFOs "signals" don't feed into each other, rather there is a hierarchy of "truth" where values are derived:
```
lfo3 --> lfo2 --> lfo1 --> gui 
```
i.e. if you set the `size` in `lfo1` and `lfo2`, the value will be derived from `lfo2` and the value from `lfo1` will be ignored.

