### PR TITLE
Fix screenshots

### DIFF
--- a/public/src/app.js
+++ b/public/src/app.js
@@ -59,7 +59,7 @@ const app = (s) => {
   s.keyPressed = () => {
     // p key
     if (s.keyCode === 80) {
-      s.save("paint with friends.png", false); // false prevents canvas from being cleared
+      s.save("paint with friends.png");
     }
   };
 };

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -6,9 +6,11 @@ import { LocalStorage } from "./utils/LocalStorage.js";
 import { userList } from "./components/userList.js";
 import { initUsername } from "./utils/initUsername.js";
 import { chatMessages } from "./components/chatMessages.js";
+import { KeyManager } from "./utils/KeyManager.js";
 
 const app = (s) => {
   const socket = io.connect("http://localhost:3000");
+  const keysPressed = new KeyManager(s);
 
   s.setup = function () {
     s.createCanvas(dimensions.width, dimensions.height);
@@ -57,10 +59,11 @@ const app = (s) => {
   };
 
   s.keyPressed = () => {
-    // p key
-    if (s.keyCode === 80) {
-      s.save("paint with friends.png");
-    }
+    keysPressed.addKey(s.keyCode);
+  };
+
+  s.keyReleased = () => {
+    keysPressed.removeKey(s.keyCode);
   };
 };
 

--- a/public/src/utils/KeyManager.js
+++ b/public/src/utils/KeyManager.js
@@ -1,0 +1,34 @@
+export class KeyManager {
+  constructor(p5) {
+    this.keysPressed = [];
+    this.commands = [
+      {
+        name: "screenshot",
+        keys: [17, 88], // ctrl + x
+        execute: p5.save.bind(p5),
+        param: "paint with friends.png",
+      },
+    ];
+  }
+
+  addKey = (key) => {
+    this.keysPressed.push(key);
+    this.checkForValidCommand();
+  };
+
+  removeKey = (key) => {
+    this.keysPressed = this.keysPressed.filter((key) => key !== key);
+  };
+
+  checkForValidCommand = () => {
+    this.commands.forEach((command) => {
+      if (this.arrayEquals(command.keys, this.keysPressed)) {
+        command.execute(command.param);
+      }
+    });
+  };
+
+  arrayEquals = (a, b) => {
+    return a.every((val, idx) => val === b[idx]);
+  };
+}


### PR DESCRIPTION
So, remember how I "magically" guessed that passing `false` into p5's `save()` (screenshot) would prevent it from clearing the canvas? I don't know what the hell was happening, but that a) is not valid syntax and was throwing an error and b) even without the `false` it doesn't seem to be clearing the canvas now? 🤔

At any rate, I fixed it, but then realized that with the introduction of chat, it posed an issue where whenever you would type `p`, it would download a screenshot. I thought about adding a flag that would indicate that any `<input>` element was currently in-focus (i.e. you're typing in a text input), and to just ignore the `save` command if that was the case. But I ended up moving towards `ctrl`-based hotkeys to work around that and moved the hotkey to `CTRL` + `x` (export, I guess?). I added a class for tracking which keys are pressed and mapping them to an array of commands. I like this because a) we can move the commands outside of `app.js` and b) we could add more hotkeys, possibly for the actual drawing functions (think photoshop or similar). The only kinda sucky thing is that the browser has a lot of default hotkeys, which is why I didn't make it the more obvious `CTRL` + `p` (print). There might be a way around that, but in any case the commands can be totally arbitrary, so there are infinite combinations of possible commands (they also don't have to be just 2 keys).