### PR TITLE
chat fixes/improvements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
 
 <body>
 
-    <form id="username-form" class="flex">
+    <form id="username-form" class="flex hide">
         <label class="flex column">
             username
             <input id="name-input" type="text">
@@ -54,6 +54,7 @@
                 </li>
             </template>
         </ul>
+        <button id="change-username">change username</button>
     </div>
 
 

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -8,9 +8,11 @@ import { initUsername } from "./utils/initUsername.js";
 import { chatMessages } from "./components/chatMessages.js";
 
 const app = (s) => {
-  const socket = io.connect("http://localhost:3000");
+  let socket;
 
   s.setup = function () {
+    socket = io.connect("http://localhost:3000");
+
     s.createCanvas(dimensions.width, dimensions.height);
     s.background(0);
     s.rectMode(s.CENTER);
@@ -35,18 +37,18 @@ const app = (s) => {
     socket.on("connected", (socketID) => {
       LocalStorage.set("pwf_socket", socketID);
       initUsername(socketID);
+    });
 
-      socket.on("update", (paintProperties) => {
-        updateDrawing(s, paintProperties);
-      });
+    socket.on("update", (paintProperties) => {
+      updateDrawing(s, paintProperties);
+    });
 
-      socket.on("members", (users) => {
-        userList(users);
-      });
+    socket.on("members", (users) => {
+      userList(users);
+    });
 
-      socket.on("message", (message) => {
-        chatMessages(message);
-      });
+    socket.on("message", (message) => {
+      chatMessages(message);
     });
   };
 

--- a/public/src/components/userList.js
+++ b/public/src/components/userList.js
@@ -1,3 +1,5 @@
+import { LocalStorage } from "../utils/LocalStorage.js";
+
 export const userList = (users) => {
   // grab the existing list & template
   const ul = document.getElementById("username-list");
@@ -11,7 +13,15 @@ export const userList = (users) => {
   // create updated list
   Object.values(users).forEach((username) => {
     const listItem = document.importNode(template.content, true);
-    listItem.querySelector(".username").textContent = username;
+    let text = "";
+
+    if (username === LocalStorage.get("pwf_username")) {
+      text = `${username} (you)`;
+    } else {
+      text = username;
+    }
+
+    listItem.querySelector(".username").textContent = text;
     newList.appendChild(listItem);
   });
 

--- a/public/src/components/userList.js
+++ b/public/src/components/userList.js
@@ -13,9 +13,11 @@ export const userList = (users) => {
   // create updated list
   Object.values(users).forEach((username) => {
     const listItem = document.importNode(template.content, true);
+    const storedUsername = LocalStorage.get("pwf_username");
+    const socketID = LocalStorage.get("pwf_socket");
     let text = "";
 
-    if (username === LocalStorage.get("pwf_username")) {
+    if (username === storedUsername || username === socketID) {
       text = `${username} (you)`;
     } else {
       text = username;

--- a/public/src/components/userList.js
+++ b/public/src/components/userList.js
@@ -18,12 +18,12 @@ export const userList = (users) => {
     let text = "";
 
     if (username === storedUsername || username === socketID) {
-      text = `${username} (you)`;
+      text = `${username} <span class="dim">(you)</span>`;
     } else {
       text = username;
     }
 
-    listItem.querySelector(".username").textContent = text;
+    listItem.querySelector(".username").innerHTML = text;
     newList.appendChild(listItem);
   });
 

--- a/public/src/style.css
+++ b/public/src/style.css
@@ -94,6 +94,10 @@ ul {
   animation-delay: 55s;
 }
 
+.hide {
+  display: none;
+}
+
 /* COMPONENT STYLES */
 
 #username-form {
@@ -161,6 +165,12 @@ ul {
 #username-list li p {
   color: var(--white);
   text-align: right;
+}
+
+#change-username {
+  float: right;
+  font-size: 10px;
+  margin-top: 10px;
 }
 
 /* ANIMATIONS */

--- a/public/src/style.css
+++ b/public/src/style.css
@@ -104,7 +104,7 @@ ul {
   max-width: 200px;
   position: fixed;
   bottom: 20px;
-  left: 20px;
+  left: 350px;
 }
 
 #username-form button,
@@ -117,14 +117,14 @@ ul {
   max-width: 200px;
   position: fixed;
   bottom: 20px;
-  left: 350px;
+  left: 20px;
 }
 
 #message-container {
-  width: 225px;
+  width: 250px;
   position: fixed;
-  bottom: 65px;
-  left: 350px;
+  bottom: 70px;
+  left: 20px;
 }
 
 .chat-list-item {

--- a/public/src/style.css
+++ b/public/src/style.css
@@ -98,6 +98,10 @@ ul {
   display: none;
 }
 
+.dim {
+  opacity: 0.5;
+}
+
 /* COMPONENT STYLES */
 
 #username-form {

--- a/public/src/ui.js
+++ b/public/src/ui.js
@@ -11,6 +11,7 @@ updateUsernameBtn.addEventListener("click", (e) => {
   const username = nameInput.value;
   const socketID = LocalStorage.get("pwf_socket");
   LocalStorage.set("pwf_username", username);
+  nameInput.value = "";
   Fetch.post("update-username", { id: socketID, username });
 });
 

--- a/public/src/ui.js
+++ b/public/src/ui.js
@@ -2,9 +2,10 @@ import { Fetch } from "./utils/Fetch.js";
 import { LocalStorage } from "./utils/LocalStorage.js";
 
 // username input
-
 const nameInput = document.querySelector("#name-input");
 const updateUsernameBtn = document.querySelector("#update-username");
+const changeUsernameContainer = document.querySelector("#username-form");
+const changeNameBtn = document.querySelector("#change-username");
 
 updateUsernameBtn.addEventListener("click", (e) => {
   e.preventDefault(); // prevent page refresh on submit
@@ -12,7 +13,12 @@ updateUsernameBtn.addEventListener("click", (e) => {
   const socketID = LocalStorage.get("pwf_socket");
   LocalStorage.set("pwf_username", username);
   nameInput.value = "";
+  changeUsernameContainer.classList.toggle("hide");
   Fetch.post("update-username", { id: socketID, username });
+});
+
+changeNameBtn.addEventListener("click", () => {
+  changeUsernameContainer.classList.toggle("hide");
 });
 
 // chat input


### PR DESCRIPTION
This PR primarily fixes (at least I'm pretty sure?) a race condition that would sporadically occur, where the WS connection wasn't made in time to receive updates on the various channels (`members` when members join/leave, `message` when messages are sent, etc.). Pretty bad issue, because it meant that the messaging and displaying of members wouldn't work.

Aside from that I made a couple small UX/UI improvements:
- swap the location of the messaging & change username forms
- hide update username form by default (as you wouldn't use it frequently and adds UI noise)
  - instead the form can be toggled w/ a new button in the members display list 
- automatically clear and hide the change username input form when submitted
- indicate the current user by appending a little dimmed "(you)" next to a user's name
  - by default everyone just has websocket IDs for usernames, so it's not necessarily obvious who you are if you're just joining 

before:
![image](https://user-images.githubusercontent.com/3317203/148699702-d3891289-217e-43c2-8600-ee11b17f8fb0.png)

after: 
![image](https://user-images.githubusercontent.com/3317203/148699694-99aafcb6-8c0b-455d-9102-2d336d511a7f.png)
