### PR TITLE
convert backend code to ESM

### DIFF
--- a/Connections.js
+++ b/Connections.js
@@ -1,4 +1,4 @@
-class Connections {
+export class Connections {
   constructor(io) {
     this.io = io;
     this.connections = {};
@@ -33,5 +33,3 @@ class Connections {
     return this.connections[id];
   };
 }
-
-module.exports = Connections;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "dev": "nodemon server.js"
   },

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
-const express = require("express");
-const socket = require("socket.io");
-const Connections = require("./Connections.js");
+import express from "express";
+import { Server } from "socket.io";
+import { Connections } from "./Connections.js";
 
 const port = 3000;
 
@@ -13,7 +13,7 @@ const server = app.listen(port, () =>
   console.log(`server listening on port ${port}`)
 );
 
-const io = socket(server);
+const io = new Server(server);
 const connectedUsers = new Connections(io);
 
 io.sockets.on("connection", (socket) => {


### PR DESCRIPTION
This PR changes the way the backend (node.js) part of the app handles exporting/importing files. By default node uses commonJS imports (`const someDependency = require("some-dependency")`) while the frontend code we've been writing uses the newer ESM syntax (`import someDependency from "some-dependency"`). [The two don't play nice together](https://redfin.engineering/node-modules-at-war-why-commonjs-and-es-modules-cant-get-along-9617135eeca1), which we will need to we can reuse the frontend drawing code on the server to synchronize the canvas when people join. Specifically, so we can `import { updateDrawing } from "./utils/drawing.js"` in the server code.
