### PR TITLE
fix noise waveform

### DIFF
--- a/public/src/utils/Waveforms.js
+++ b/public/src/utils/Waveforms.js
@@ -5,24 +5,25 @@ export class Waveforms {
   }
 
   static square(min, x) {
-    if (x <= Math.PI) {
+    if (this._tauMod(x) <= Math.PI) {
       return this._normalize(-1, min);
     }
     return this._normalize(1, min);
   }
 
   static triangle(min, x) {
-    if (x <= Math.PI) {
-      const expression = x / (Math.PI * 0.5) - 1;
+    const value = this._tauMod(x);
+    if (value <= Math.PI) {
+      const expression = value / (Math.PI * 0.5) - 1;
       return this._normalize(expression, min);
     }
 
-    const expression = (x - Math.PI) / (-Math.PI * 0.5) + 1;
+    const expression = (value - Math.PI) / (-Math.PI * 0.5) + 1;
     return this._normalize(expression, min);
   }
 
   static saw(min, x) {
-    const expression = x / Math.PI - 1;
+    const expression = this._tauMod(x) / Math.PI - 1;
     return this._normalize(expression, min);
   }
 
@@ -45,5 +46,15 @@ export class Waveforms {
   static _normalize(x, min) {
     const scaledMin = min * 0.01;
     return window.p5.prototype.map(x, -1, 1, scaledMin, 1);
+  }
+
+  /**
+   * Mods an input value by tau, used in constant waveforms.
+   *
+   * @param {number} x
+   * @returns {number} 0 - tau
+   */
+  static _tauMod(x) {
+    return (x %= Math.PI * 2);
   }
 }

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -93,8 +93,6 @@ export const useLfo = (p5, gui, lfo) => {
     y
   ) {
     lfo.value += speed;
-    // up to 2 * PI (see Waveforms.js implementation)
-    lfo.value %= Math.PI * 2;
   }
 
   if (x) {


### PR DESCRIPTION
This PR fixes a bug with the implementation of the noise waveform. Because we were modding the input value by `tau` (2*pi), the values emitted by the noise function would "loop" regularly/periodically. In other words, the desired input is just a number that increments infinitely, no periodic resetting. So now the underlying `lfo.value` just increments up based on the `lfo.speed`, and the `Waveforms` class now has a private method for modding input values only where we need them (triangle, square, and saw). It is not needed in the sine waveform despite it's periodic-ness because internally it just called `Math.sin` which is happy with numbers that just go brrrrrrrr