### PR TITLE
smooth zooming

### DIFF
--- a/public/src/style.css
+++ b/public/src/style.css
@@ -37,6 +37,8 @@ body {
 canvas {
   display: block;
   box-shadow: 2px 20px 40px rgba(0, 0, 0, 0.3);
+  transition: 300ms ease-in-out transform;
+  will-change: transform;
 }
 
 label {

--- a/public/src/utils/Camera.js
+++ b/public/src/utils/Camera.js
@@ -19,10 +19,12 @@ export class Camera {
   };
 
   zoom = () => {
+    this.canvas.style.transition = "300ms ease-in-out transform";
     this.canvas.style.transform = `scale(${this.zoomAmount}) translate(${this.offset.x}px, ${this.offset.y}px)`;
   };
 
   pan = (movementX, movementY) => {
+    this.canvas.style.transition = "none";
     this.offset.x += movementX * (1 / this.zoomAmount);
     this.offset.y += movementY * (1 / this.zoomAmount);
 


### PR DESCRIPTION
This PR adds some easing/smoothing to the zoom.

The implementation is a bit of a hack because both the zooming and panning is implemented with a single css property (`transform`) but we only want to smooth zooming (smoothing the panning makes it feel floaty and unresponsive). So the workaround is to just kill the css `transition` when panning, and re-enable it when zooming. 