### PR TITLE
cursors

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -79,6 +79,7 @@
         <button id="change-username">change username</button>
     </div>
 
+    <div id="p5-cursors"></div>
 
 </body>
 

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -115,7 +115,12 @@ const app = (s) => {
   };
 
   s.mouseReleased = () => {
-    if (!state.isDrawing) document.body.style.cursor = "grab";
+    if (!state.isDrawing) {
+      document.body.style.cursor = "grab";
+    } else {
+      // if done drawing, clear the cursors
+      socket.emit(EVENTS.MOUSE_RELEASED);
+    }
 
     // reset last coord positions to null to re-trigger init
     state.lastX = state.lastY = null;

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -94,10 +94,12 @@ const app = (s) => {
       updateDrawing(s, paintProperties);
       socket.emit(
         EVENTS.DRAW_UPDATE,
-        convertToLeanPaintProperties(paintProperties)
+        convertToLeanPaintProperties(
+          paintProperties,
+          LocalStorage.get("pwf_username")
+        )
       );
       s.setLastCoords();
-      s.broadcastMouse();
     } else {
       camera.pan(movementX, movementY);
     }
@@ -117,14 +119,6 @@ const app = (s) => {
 
     // reset last coord positions to null to re-trigger init
     state.lastX = state.lastY = null;
-  };
-
-  s.broadcastMouse = () => {
-    socket?.emit(EVENTS.CURSOR_UPDATE, {
-      x: Camera.scaleByZoomAmount(s.mouseX, camera.zoomAmount),
-      y: Camera.scaleByZoomAmount(s.mouseY, camera.zoomAmount),
-      username: LocalStorage.get("pwf_username"),
-    });
   };
 };
 

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -22,7 +22,7 @@ const app = (s) => {
   let socket, canvas, camera;
 
   s.initCanvas = (serializedCanvas) => {
-    canvas = document.querySelector("canvas");
+    canvas = document.querySelector("#app");
     const ctx = canvas.getContext("2d");
     const img = new Image();
     img.onload = function () {
@@ -33,7 +33,8 @@ const app = (s) => {
 
   s.setup = async function () {
     const initialCanvasState = await Fetch.get("canvas");
-    s.createCanvas(dimensions.width, dimensions.height);
+    const cnv = s.createCanvas(dimensions.width, dimensions.height);
+    cnv.id("app");
     s.initCanvas(initialCanvasState);
     camera = new Camera(canvas);
 
@@ -45,7 +46,7 @@ const app = (s) => {
     initGuiPanels(s, this);
 
     // init separate sketch for rendering cursors
-    new p5(initCursors(socket));
+    new p5(initCursors(socket, camera));
 
     socket.on(EVENTS.CONNECTED, (socketID) => {
       LocalStorage.set("pwf_socket", socketID);
@@ -106,8 +107,7 @@ const app = (s) => {
   };
 
   s.mouseWheel = ({ delta }) => {
-    camera.set(delta * -1);
-    camera.zoom();
+    camera.zoom(delta);
   };
 
   s.mousePressed = () => {

--- a/public/src/constants.js
+++ b/public/src/constants.js
@@ -23,6 +23,7 @@ export const EVENTS = {
   DISCONNECT: "disconnect",
   MEMBERS_CHANGED: "membersChanged",
   MESSAGE: "message",
+  CURSOR_UPDATE: "cursorUpdate",
 };
 
 const GUI_WIDTH = 200;

--- a/public/src/constants.js
+++ b/public/src/constants.js
@@ -23,7 +23,7 @@ export const EVENTS = {
   DISCONNECT: "disconnect",
   MEMBERS_CHANGED: "membersChanged",
   MESSAGE: "message",
-  CURSOR_UPDATE: "cursorUpdate",
+  MOUSE_RELEASED: "mouseReleased",
 };
 
 const GUI_WIDTH = 200;

--- a/public/src/cursors.js
+++ b/public/src/cursors.js
@@ -1,0 +1,23 @@
+import { dimensions, EVENTS } from "./constants.js";
+
+export const initCursors = (socket) => {
+  const cursors = (s) => {
+    s.setup = () => {
+      const canvas = s.createCanvas(dimensions.width, dimensions.height);
+      canvas.parent("p5-cursors");
+
+      socket.on(EVENTS.CURSOR_UPDATE, ({ x, y, username }) => {
+        s.drawCursor(x, y, username);
+      });
+    };
+
+    s.drawCursor = (x, y, username) => {
+      s.clear();
+      s.fill(0, 255, 0);
+      s.circle(x, y, 10);
+      s.text(username, x + 8, y + 3);
+    };
+  };
+
+  return cursors;
+};

--- a/public/src/cursors.js
+++ b/public/src/cursors.js
@@ -1,12 +1,16 @@
 import { dimensions, EVENTS } from "./constants.js";
+import { Camera } from "./utils/Camera.js";
 
-export const initCursors = (socket) => {
+export const initCursors = (socket, camera) => {
   const cursors = (s) => {
     let color;
 
     s.setup = () => {
       const canvas = s.createCanvas(dimensions.width, dimensions.height);
+      canvas.id("cursors");
       canvas.parent("p5-cursors");
+
+      camera.registerCursorCanvas(document.querySelector("#cursors"));
 
       s.textFont("JetBrains Mono");
 
@@ -26,10 +30,11 @@ export const initCursors = (socket) => {
       s.clear();
       s.fill(color);
       s.noStroke();
-      s.circle(x, y, 10);
+      s.circle(x, y, Camera.scaleByZoomAmount(10, camera.zoomAmount));
 
       s.stroke(0);
       s.strokeWeight(2);
+      s.textSize(Camera.scaleByZoomAmount(12, camera.zoomAmount));
       s.text(username, x + 8, y + 3);
     };
 

--- a/public/src/cursors.js
+++ b/public/src/cursors.js
@@ -6,7 +6,11 @@ export const initCursors = (socket) => {
       const canvas = s.createCanvas(dimensions.width, dimensions.height);
       canvas.parent("p5-cursors");
 
-      socket.on(EVENTS.CURSOR_UPDATE, ({ x, y, username }) => {
+      socket.on(EVENTS.DRAW_UPDATE, (data) => {
+        // first 2 elements of lean paint proerties are current mouse coords
+        const [x, y] = data;
+        // last element is username
+        const username = data[data.length - 1];
         s.drawCursor(x, y, username);
       });
     };

--- a/public/src/cursors.js
+++ b/public/src/cursors.js
@@ -2,6 +2,8 @@ import { dimensions, EVENTS } from "./constants.js";
 
 export const initCursors = (socket) => {
   const cursors = (s) => {
+    let color = s.color(0, 255, 0);
+
     s.setup = () => {
       const canvas = s.createCanvas(dimensions.width, dimensions.height);
       canvas.parent("p5-cursors");
@@ -19,8 +21,12 @@ export const initCursors = (socket) => {
 
     s.drawCursor = (x, y, username) => {
       s.clear();
-      s.fill(0, 255, 0);
+      s.fill(color);
+      s.noStroke();
       s.circle(x, y, 10);
+
+      s.stroke(0);
+      s.strokeWeight(2);
       s.text(username, x + 8, y + 3);
     };
   };

--- a/public/src/cursors.js
+++ b/public/src/cursors.js
@@ -2,7 +2,7 @@ import { dimensions, EVENTS } from "./constants.js";
 
 export const initCursors = (socket) => {
   const cursors = (s) => {
-    let color = s.color(0, 255, 0);
+    let color;
 
     s.setup = () => {
       const canvas = s.createCanvas(dimensions.width, dimensions.height);
@@ -15,6 +15,8 @@ export const initCursors = (socket) => {
         const [x, y] = data;
         // last element is username
         const username = data[data.length - 1];
+        color = s.usernameToColor(username);
+        // color = s.color(s.usernameToColor(username));
         s.drawCursor(x, y, username);
       });
     };
@@ -28,6 +30,34 @@ export const initCursors = (socket) => {
       s.stroke(0);
       s.strokeWeight(2);
       s.text(username, x + 8, y + 3);
+    };
+
+    s.usernameToColor = (username) => {
+      var colors = [
+        "#e51c23",
+        "#e91e63",
+        "#9c27b0",
+        "#673ab7",
+        "#3f51b5",
+        "#5677fc",
+        "#03a9f4",
+        "#00bcd4",
+        "#009688",
+        "#259b24",
+        "#8bc34a",
+        "#afb42b",
+        "#ff9800",
+        "#ff5722",
+      ];
+
+      let hash = 0;
+      if (username.length === 0) return hash;
+      for (let i = 0; i < username.length; i++) {
+        hash = username.charCodeAt(i) + ((hash << 5) - hash);
+        hash = hash & hash;
+      }
+      hash = ((hash % colors.length) + colors.length) % colors.length;
+      return colors[hash];
     };
   };
 

--- a/public/src/cursors.js
+++ b/public/src/cursors.js
@@ -6,6 +6,8 @@ export const initCursors = (socket) => {
       const canvas = s.createCanvas(dimensions.width, dimensions.height);
       canvas.parent("p5-cursors");
 
+      s.textFont("JetBrains Mono");
+
       socket.on(EVENTS.DRAW_UPDATE, (data) => {
         // first 2 elements of lean paint proerties are current mouse coords
         const [x, y] = data;

--- a/public/src/cursors.js
+++ b/public/src/cursors.js
@@ -11,10 +11,8 @@ export const initCursors = (socket) => {
       s.textFont("JetBrains Mono");
 
       socket.on(EVENTS.DRAW_UPDATE, (data) => {
-        // first 2 elements of lean paint proerties are current mouse coords
-        const [x, y] = data;
-        // last element is username
-        const username = data[data.length - 1];
+        // first 3 elements of paint props are username & mouse x/y
+        const [username, x, y] = data;
         color = s.usernameToColor(username);
         s.drawCursor(x, y, username);
       });

--- a/public/src/cursors.js
+++ b/public/src/cursors.js
@@ -16,7 +16,6 @@ export const initCursors = (socket) => {
         // last element is username
         const username = data[data.length - 1];
         color = s.usernameToColor(username);
-        // color = s.color(s.usernameToColor(username));
         s.drawCursor(x, y, username);
       });
     };
@@ -32,8 +31,9 @@ export const initCursors = (socket) => {
       s.text(username, x + 8, y + 3);
     };
 
+    // https://gist.github.com/0x263b/2bdd90886c2036a1ad5bcf06d6e6fb37
     s.usernameToColor = (username) => {
-      var colors = [
+      const colors = [
         "#e51c23",
         "#e91e63",
         "#9c27b0",

--- a/public/src/cursors.js
+++ b/public/src/cursors.js
@@ -18,6 +18,10 @@ export const initCursors = (socket) => {
         color = s.usernameToColor(username);
         s.drawCursor(x, y, username);
       });
+
+      socket.on(EVENTS.MOUSE_RELEASED, () => {
+        s.clear();
+      });
     };
 
     s.drawCursor = (x, y, username) => {

--- a/public/src/style.css
+++ b/public/src/style.css
@@ -41,6 +41,12 @@ canvas {
   will-change: transform;
 }
 
+#p5-cursors {
+  position: absolute;
+  z-index: 2;
+  pointer-events: none;
+}
+
 label {
   color: var(--white);
 }

--- a/public/src/utils/Camera.js
+++ b/public/src/utils/Camera.js
@@ -2,13 +2,20 @@ export class Camera {
   constructor(canvas) {
     this.zoomAmount = 1;
     this.offset = { x: 0, y: 0 };
-    this.canvas = canvas;
+    this.canvases = {
+      app: canvas,
+      cursors: null,
+    };
     this.maxZoom = 1;
     this.minZoom = 0.2;
     this.scrollSensitivity = 0.001;
   }
 
-  set = (delta) => {
+  registerCursorCanvas = (canvas) => {
+    this.canvases.cursors = canvas;
+  };
+
+  _setZoom = (delta) => {
     const rawUpdatedValue = this.zoomAmount + delta * this.scrollSensitivity;
     const constrained = Math.min(
       Math.max(this.minZoom, rawUpdatedValue),
@@ -18,17 +25,34 @@ export class Camera {
     this.zoomAmount = constrained;
   };
 
-  zoom = () => {
-    this.canvas.style.transition = "300ms ease-in-out transform";
-    this.canvas.style.transform = `scale(${this.zoomAmount}) translate(${this.offset.x}px, ${this.offset.y}px)`;
+  _setPan = (movementX, movementY) => {
+    this.offset.x += Camera.scaleByZoomAmount(movementX, this.zoomAmount);
+    this.offset.y += Camera.scaleByZoomAmount(movementY, this.zoomAmount);
+  };
+
+  zoom = (delta) => {
+    this._setZoom(delta * -1);
+    Object.values(this.canvases).forEach((canvas) => {
+      if (canvas) this._zoomCanvas(canvas);
+    });
+  };
+
+  _zoomCanvas = (canvas) => {
+    canvas.style.transition = "300ms ease-in-out transform";
+    canvas.style.transform = `scale(${this.zoomAmount}) translate(${this.offset.x}px, ${this.offset.y}px)`;
   };
 
   pan = (movementX, movementY) => {
-    this.canvas.style.transition = "none";
-    this.offset.x += Camera.scaleByZoomAmount(movementX, this.zoomAmount);
-    this.offset.y += Camera.scaleByZoomAmount(movementY, this.zoomAmount);
+    this._setPan(movementX, movementY);
 
-    this.canvas.style.transform = `scale(${this.zoomAmount}) translate(${this.offset.x}px, ${this.offset.y}px)`;
+    Object.values(this.canvases).forEach((canvas) => {
+      if (canvas) this._panCanvas(canvas);
+    });
+  };
+
+  _panCanvas = (canvas) => {
+    canvas.style.transition = "none";
+    canvas.style.transform = `scale(${this.zoomAmount}) translate(${this.offset.x}px, ${this.offset.y}px)`;
   };
 
   static scaleByZoomAmount = (coordinate, zoomAmount) => {

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -182,7 +182,7 @@ const useRainbow = (p5, lfoValue, lfoGui, opacity) => {
  * @param {object} paintProperties
  * @returns {array} leanPaintProperties
  */
-export const convertToLeanPaintProperties = (paintProperties) => {
+export const convertToLeanPaintProperties = (paintProperties, username) => {
   return [
     paintProperties.x,
     paintProperties.y,
@@ -197,6 +197,7 @@ export const convertToLeanPaintProperties = (paintProperties) => {
     paintProperties.prevX,
     paintProperties.prevY,
     paintProperties.strokeWeight,
+    username, // this should always be last
   ];
 };
 

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -184,6 +184,7 @@ const useRainbow = (p5, lfoValue, lfoGui, opacity) => {
  */
 export const convertToLeanPaintProperties = (paintProperties, username) => {
   return [
+    username,
     paintProperties.x,
     paintProperties.y,
     paintProperties.fillColor,
@@ -197,7 +198,6 @@ export const convertToLeanPaintProperties = (paintProperties, username) => {
     paintProperties.prevX,
     paintProperties.prevY,
     paintProperties.strokeWeight,
-    username, // this should always be last
   ];
 };
 
@@ -210,18 +210,18 @@ export const convertToLeanPaintProperties = (paintProperties, username) => {
  */
 export const convertLeanPaintPropertiesToObject = (leanPaintProperties) => {
   return {
-    x: leanPaintProperties[0],
-    y: leanPaintProperties[1],
-    fillColor: leanPaintProperties[2],
-    fillOpacity: leanPaintProperties[3],
-    strokeColor: leanPaintProperties[4],
-    strokeOpacity: leanPaintProperties[5],
-    mirrorX: leanPaintProperties[6],
-    mirrorY: leanPaintProperties[7],
-    shape: leanPaintProperties[8],
-    size: leanPaintProperties[9],
-    prevX: leanPaintProperties[10],
-    prevY: leanPaintProperties[11],
-    strokeWeight: leanPaintProperties[12],
+    x: leanPaintProperties[1],
+    y: leanPaintProperties[2],
+    fillColor: leanPaintProperties[3],
+    fillOpacity: leanPaintProperties[4],
+    strokeColor: leanPaintProperties[5],
+    strokeOpacity: leanPaintProperties[6],
+    mirrorX: leanPaintProperties[7],
+    mirrorY: leanPaintProperties[8],
+    shape: leanPaintProperties[9],
+    size: leanPaintProperties[10],
+    prevX: leanPaintProperties[11],
+    prevY: leanPaintProperties[12],
+    strokeWeight: leanPaintProperties[13],
   };
 };

--- a/server.js
+++ b/server.js
@@ -30,9 +30,13 @@ io.sockets.on(EVENTS.NEW_CONNECTION, (socket) => {
   socket.emit(EVENTS.CONNECTED, socket.id);
   connectedUsers.addConnection(socket.id);
 
-  socket.on(EVENTS.DRAW_UPDATE, (data) => {
-    socket.broadcast.emit(EVENTS.DRAW_UPDATE, data);
-    eventEmitter.emit(EVENTS.DRAW_UPDATE, data);
+  socket.on(EVENTS.DRAW_UPDATE, (paintProperties) => {
+    socket.broadcast.emit(EVENTS.DRAW_UPDATE, paintProperties);
+    eventEmitter.emit(EVENTS.DRAW_UPDATE, paintProperties);
+  });
+
+  socket.on(EVENTS.CURSOR_UPDATE, (mouseCoords) => {
+    socket.broadcast.emit(EVENTS.CURSOR_UPDATE, mouseCoords);
   });
 
   socket.on(EVENTS.DISCONNECT, () => {

--- a/server.js
+++ b/server.js
@@ -35,8 +35,8 @@ io.sockets.on(EVENTS.NEW_CONNECTION, (socket) => {
     eventEmitter.emit(EVENTS.DRAW_UPDATE, paintProperties);
   });
 
-  socket.on(EVENTS.CURSOR_UPDATE, (mouseCoords) => {
-    socket.broadcast.emit(EVENTS.CURSOR_UPDATE, mouseCoords);
+  socket.on(EVENTS.MOUSE_RELEASED, () => {
+    socket.broadcast.emit(EVENTS.MOUSE_RELEASED);
   });
 
   socket.on(EVENTS.DISCONNECT, () => {


### PR DESCRIPTION
This PR adds cursors that show who is drawing what ala Figma. 

![image](https://user-images.githubusercontent.com/3317203/158298187-d3e948af-c4f3-4afb-9813-c737ae9d6006.png)

The implementation is to render a separate p5 canvas to render only the cursors on top of the canvas. The reason is twofold - 1) we need to call p5's `clear()` to make sure the cursors don't create trails and we _cannot_ call that on the main canvas (it deletes everything) and 2) this means you can download the canvas while cursors are shown and it will be pristine/cursor-less. This is a bit annoying since I added zooming/panning though, so now _both_ canvases must have 1:1 transforms to keep everything synced up (see changes to `Camera.js`). I also made use of the `Camera.scaleToZoom` in an unexpected way for similar reasons, to make sure the cursors are always the same size even when you zoom out (nice).

As for the cursors themselves, right now they are just circles with the username printed beside it. The colors are assigned by hashing the username (which now must be sent over the wire along with the usual `paintProperties`) and using the hash to select a value from a pre-populated array of nice colors. They also have black stroke outlines so the usernames should be legible against any color (in theory anyway). The hashing code was borrowed from [this sick gist](https://gist.github.com/0x263b/2bdd90886c2036a1ad5bcf06d6e6fb37).

in summary:
- there is now a new (client-side only) p5 canvas that sits over the main one and just renders cursors
- now that there are multiple canvases i've given them explicit `id`s so they can be referenced independently
- we have to send usernames over the wire w/ all the paint updates to draw cursors
- zooming/panning makes things a bit tricky 😅 