### PR TITLE
conditionally hide unused params

### DIFF
--- a/public/lib/quicksettings.js
+++ b/public/lib/quicksettings.js
@@ -25,7 +25,7 @@
   }
 
   function createElement(type, id, className, parent) {
-    var element = document.createElement(type);
+    var element = document.createElement(type, id, className);
     if (!element) return;
     element.id = id;
     if (className) {
@@ -150,8 +150,9 @@
       if (!cssInjected) {
         injectCSS();
       }
+
       this._bindHandlers();
-      this._createPanel(x, y, parent);
+      this._createPanel(x, y, parent, title);
       this._createTitleBar(title || "QuickSettings");
       this._createContent();
     },
@@ -242,10 +243,10 @@
     // region CREATION FUNCTIONS
     ////////////////////////////////////////////////////////////////////////////////
 
-    _createPanel: function (x, y, parent) {
+    _createPanel: function (x, y, parent, title) {
       this._panel = createElement(
         "div",
-        null,
+        title,
         "qs_main",
         parent || document.body
       );

--- a/public/src/initialState.js
+++ b/public/src/initialState.js
@@ -48,12 +48,12 @@ const lfoParams = {
 
 // params that can be controlled via LFO
 const lfoControllableParams = [
-  p.FILL_OPACITY,
-  p.STROKE_OPACITY,
-  p.SIZE,
-  p.STROKE_WEIGHT,
   p.FILL_COLOR,
+  p.FILL_OPACITY,
   p.STROKE_COLOR,
+  p.STROKE_OPACITY,
+  p.STROKE_WEIGHT,
+  p.SIZE,
   p.X,
   p.Y,
 ];

--- a/public/src/utils/initUI.js
+++ b/public/src/utils/initUI.js
@@ -28,7 +28,6 @@ export const initGuiPanels = (s, thisContext) => {
   lfo3Gui.collapse();
 };
 
-// need to split this up per-lfo, the areColorOptionsSelected bools are getting out of sync
 const handleVisibleLfoParams = (lfoIndex) => {
   const colorOptions = ["saturation", "brightness"];
   // set initial visible params

--- a/public/src/utils/initUI.js
+++ b/public/src/utils/initUI.js
@@ -1,5 +1,5 @@
 import { state } from "../initialState.js";
-import { GUI_GUTTER, GUI_OFFSET } from "../constants.js";
+import { GUI_GUTTER, GUI_OFFSET, paintProperties as p } from "../constants.js";
 
 export const initGuiPanels = (s, thisContext) => {
   const gui = s.createGui("paintbrush", thisContext);
@@ -20,4 +20,66 @@ export const initGuiPanels = (s, thisContext) => {
   lfo3Gui.setPosition(3 * GUI_OFFSET - 2 * GUI_GUTTER);
   lfo3Gui.addObject(state.lfo3.gui);
   lfo3Gui.collapse();
+
+  handleVisibleParams();
+};
+
+const handleVisibleParams = () => {
+  // conditionally hide irrevelant properties based on current shape selection
+  const shapeSelector = document.querySelector("#shape");
+
+  // initial configuration
+  const selectElement = shapeSelector.querySelector("select");
+  const currentSelection = selectElement.options[selectElement.selectedIndex];
+  hideUnusedProperties(currentSelection.value);
+
+  // update on changes to shape selection dropdown
+  shapeSelector.addEventListener("change", (e) => {
+    hideUnusedProperties(e.target.value);
+  });
+};
+
+const hideUnusedProperties = (shape) => {
+  switch (shape) {
+    case "line":
+      setParamVisibility(getUnusedParamsForShape(shape));
+      break;
+    case "circle":
+      setParamVisibility(getUnusedParamsForShape(shape));
+      break;
+    case "square":
+      setParamVisibility(getUnusedParamsForShape(shape));
+      break;
+  }
+};
+
+const getUnusedParamsForShape = (shape) => {
+  switch (shape) {
+    case "line":
+      return [p.FILL_COLOR, p.FILL_OPACITY, p.SIZE];
+    default:
+      return [];
+  }
+};
+
+const setParamVisibility = (hideList) => {
+  const ignore = [p.X, p.Y, p.PREV_X, p.PREV_Y];
+
+  // all params minus ignored props
+  const paintProperties = Object.values(p).filter(
+    (prop) => !ignore.includes(prop)
+  );
+
+  // hide ununsed params
+  hideList.forEach((property) => {
+    document.querySelector(`#${property}`).style.display = "none";
+  });
+
+  // iterate array diff and set display to block
+  const diff = paintProperties.filter((p) => !hideList.includes(p));
+
+  // show used params
+  diff.forEach((property) => {
+    document.querySelector(`#${property}`).style.display = "block";
+  });
 };

--- a/public/src/utils/initUI.js
+++ b/public/src/utils/initUI.js
@@ -9,19 +9,74 @@ export const initGuiPanels = (s, thisContext) => {
   const lfo1Gui = s.createGui("lfo1", thisContext);
   lfo1Gui.setPosition(GUI_OFFSET);
   lfo1Gui.addObject(state.lfo1.gui);
-  lfo1Gui.collapse();
 
   const lfo2Gui = s.createGui("lfo2", thisContext);
   lfo2Gui.setPosition(2 * GUI_OFFSET - GUI_GUTTER);
   lfo2Gui.addObject(state.lfo2.gui);
-  lfo2Gui.collapse();
 
   const lfo3Gui = s.createGui("lfo3", thisContext);
   lfo3Gui.setPosition(3 * GUI_OFFSET - 2 * GUI_GUTTER);
   lfo3Gui.addObject(state.lfo3.gui);
-  lfo3Gui.collapse();
 
   handleVisibleParams();
+  handleVisibleLfoParams(1);
+  handleVisibleLfoParams(2);
+  handleVisibleLfoParams(3);
+  // lfos must be in the DOM to set up listeners, immediately close after init
+  lfo1Gui.collapse();
+  lfo2Gui.collapse();
+  lfo3Gui.collapse();
+};
+
+// need to split this up per-lfo, the areColorOptionsSelected bools are getting out of sync
+const handleVisibleLfoParams = (lfoIndex) => {
+  const colorOptions = ["saturation", "brightness"];
+  // set initial visible params
+  initLfoParams(colorOptions, lfoIndex);
+
+  const fillColorToggle = document.querySelector(
+    `#lfo${lfoIndex} .qs_content #${p.FILL_COLOR}`
+  );
+  const strokeColorToggle = document.querySelector(
+    `#lfo${lfoIndex} .qs_content #${p.STROKE_COLOR}`
+  );
+  const toggles = [fillColorToggle, strokeColorToggle];
+
+  const areColorOptionsSelected = [false, false];
+
+  // add listeners to update visibility based on user changes
+  toggles.forEach((toggle, idx) => {
+    toggle.addEventListener("change", (e) => {
+      const isOn = e.target.checked;
+      areColorOptionsSelected[idx] = isOn;
+
+      // if either of the color-based options are selected, show the saturation/brightness sliders
+      if (areColorOptionsSelected.some((x) => x)) {
+        colorOptions.forEach((option) => {
+          const element = document.querySelector(
+            `#lfo${lfoIndex} .qs_content #${option}`
+          );
+          element.style.display = "block";
+        });
+      } else {
+        colorOptions.forEach((option) => {
+          const element = document.querySelector(
+            `#lfo${lfoIndex} .qs_content #${option}`
+          );
+          element.style.display = "none";
+        });
+      }
+    });
+  });
+};
+
+const initLfoParams = (colorOptions, lfoIndex) => {
+  colorOptions.forEach((option) => {
+    const element = document.querySelector(
+      `#lfo${lfoIndex} .qs_content #${option}`
+    );
+    element.style.display = "none";
+  });
 };
 
 const handleVisibleParams = () => {


### PR DESCRIPTION
This PR conditionally hides params that aren't relevant to the current paintbrush or lfo settings to simplify the UI and reduce "wtf" moments where you change a param and it has no effect. 