### PR TITLE
fix cursor flickering

### DIFF
--- a/public/src/app.js
+++ b/public/src/app.js
@@ -140,7 +140,10 @@ const app = (s) => {
       document.body.style.cursor = "grab";
     } else {
       // if done drawing, clear the cursors
-      socket.emit(EVENTS.MOUSE_RELEASED);
+      socket.emit(
+        EVENTS.MOUSE_RELEASED,
+        LocalStorage.get("pwf_username") || LocalStorage.get("pwf_socket")
+      );
     }
 
     // reset last coord positions to null to re-trigger init

--- a/public/src/cursors.js
+++ b/public/src/cursors.js
@@ -3,7 +3,7 @@ import { Camera } from "./utils/Camera.js";
 
 export const initCursors = (socket, camera) => {
   const cursors = (s) => {
-    let color;
+    const users = {};
 
     s.setup = () => {
       const canvas = s.createCanvas(dimensions.width, dimensions.height);
@@ -15,20 +15,30 @@ export const initCursors = (socket, camera) => {
       s.textFont("JetBrains Mono");
 
       socket.on(EVENTS.DRAW_UPDATE, (data) => {
-        // first 3 elements of paint props are username & mouse x/y
         const [username, x, y] = data;
-        color = s.usernameToColor(username);
-        s.drawCursor(x, y, username);
+        const color = s.usernameToColor(username);
+        s.upsertUser(username, x, y, color);
       });
 
-      socket.on(EVENTS.MOUSE_RELEASED, () => {
-        s.clear();
+      socket.on(EVENTS.MOUSE_RELEASED, (user) => {
+        delete users[user];
       });
     };
 
-    s.drawCursor = (x, y, username) => {
+    s.draw = () => {
       s.clear();
 
+      Object.keys(users).forEach((username) => {
+        const { x, y, color } = users[username];
+        s.drawCursor(x, y, username, color);
+      });
+    };
+
+    s.upsertUser = (username, x, y, color) => {
+      users[username] = { x, y, color };
+    };
+
+    s.drawCursor = (x, y, username, color) => {
       // black bg
       s.fill(0, 200);
       s.rect(

--- a/server.js
+++ b/server.js
@@ -36,8 +36,8 @@ io.sockets.on(EVENTS.NEW_CONNECTION, (socket) => {
     eventEmitter.emit(EVENTS.DRAW_UPDATE, paintProperties);
   });
 
-  socket.on(EVENTS.MOUSE_RELEASED, () => {
-    socket.broadcast.emit(EVENTS.MOUSE_RELEASED);
+  socket.on(EVENTS.MOUSE_RELEASED, (username) => {
+    socket.broadcast.emit(EVENTS.MOUSE_RELEASED, username);
   });
 
   socket.on(EVENTS.DISCONNECT, () => {


### PR DESCRIPTION
this pr fixes the cursor flickering issue by tracking the users who are currently painting inside of the `cursors` sketch (along with their x/y and the color generated from their username) and renders the whole collection rather than rendering the single most recent person who was painting. to make this work each user has to broadcast an event with their identifier (username or generated id) to the other users so their `cursor` sketch can update the current list of painters when they _stop_ painting.