### PR TITLE
drawing improvements

### DIFF
--- a/public/src/app.js
+++ b/public/src/app.js
@@ -109,19 +109,23 @@ const app = (s) => {
     }
   };
 
+  s.paint = () => {
+    s.initLastCoords();
+    const paintProperties = setupPaintProperties(s, state, camera.zoomAmount);
+    updateDrawing(s, paintProperties);
+    socket.emit(
+      EVENTS.DRAW_UPDATE,
+      convertToLeanPaintProperties(
+        paintProperties,
+        LocalStorage.get("pwf_username") || LocalStorage.get("pwf_socket")
+      )
+    );
+    s.setLastCoords();
+  };
+
   s.mouseDragged = ({ movementX, movementY }) => {
     if (state.isDrawing) {
-      s.initLastCoords();
-      const paintProperties = setupPaintProperties(s, state, camera.zoomAmount);
-      updateDrawing(s, paintProperties);
-      socket.emit(
-        EVENTS.DRAW_UPDATE,
-        convertToLeanPaintProperties(
-          paintProperties,
-          LocalStorage.get("pwf_username") || LocalStorage.get("pwf_socket")
-        )
-      );
-      s.setLastCoords();
+      s.paint();
     } else {
       camera.pan(movementX, movementY);
     }
@@ -132,7 +136,11 @@ const app = (s) => {
   };
 
   s.mousePressed = () => {
-    if (!state.isDrawing) document.body.style.cursor = "grabbing";
+    if (state.isDrawing) {
+      s.paint();
+    } else {
+      document.body.style.cursor = "grabbing";
+    }
   };
 
   s.mouseReleased = () => {

--- a/public/src/constants.js
+++ b/public/src/constants.js
@@ -12,6 +12,8 @@ export const paintProperties = {
   PREV_X: "prevX",
   PREV_Y: "prevY",
   STROKE_WEIGHT: "strokeWeight",
+  SATURATION: "saturation",
+  BRIGHTNESS: "brightness",
 };
 
 export const dimensions = { width: 3840, height: 2160 }; // 4k

--- a/public/src/initialState.js
+++ b/public/src/initialState.js
@@ -6,6 +6,8 @@ const commonState = {
   [p.FILL_OPACITY]: 255,
   [p.STROKE_COLOR]: "#349beb",
   [p.STROKE_OPACITY]: 255,
+  [p.SATURATION]: 100,
+  [p.BRIGHTNESS]: 100,
   [p.SIZE]: 15,
   [p.STROKE_WEIGHT]: 1,
   [p.MIRROR_X]: false,

--- a/public/src/initialState.js
+++ b/public/src/initialState.js
@@ -56,13 +56,15 @@ const lfoControllableParams = [
   p.SIZE,
   p.X,
   p.Y,
+  p.SATURATION,
+  p.BRIGHTNESS,
 ];
 
 // add toggle controls for each available LFO target
 lfoControllableParams.forEach((param) => (lfoParams[param] = false));
 // position optional color sliders below checkboxes to prevent layout shift
-lfoParams.saturation = 100;
-lfoParams.brightness = 100;
+// lfoParams.saturation = 100;
+// lfoParams.brightness = 100;
 
 // full client-side state object
 export const state = {

--- a/public/src/initialState.js
+++ b/public/src/initialState.js
@@ -23,8 +23,8 @@ export const initialServerState = {
 
 // client requires a few extra params for rendering UI controls
 const guiParams = {
-  ...commonState,
   [p.SHAPE]: ["line", "circle", "square"],
+  ...commonState,
   sizeMin: 5,
   sizeMax: 300,
 };

--- a/public/src/initialState.js
+++ b/public/src/initialState.js
@@ -62,9 +62,6 @@ const lfoControllableParams = [
 
 // add toggle controls for each available LFO target
 lfoControllableParams.forEach((param) => (lfoParams[param] = false));
-// position optional color sliders below checkboxes to prevent layout shift
-// lfoParams.saturation = 100;
-// lfoParams.brightness = 100;
 
 // full client-side state object
 export const state = {

--- a/public/src/utils/Camera.js
+++ b/public/src/utils/Camera.js
@@ -2,8 +2,8 @@ class Camera {
   constructor() {
     this.zoomAmount = 1;
     this.maxZoom = 1;
-    this.minZoom = 0.2;
-    this.scrollSensitivity = 0.001;
+    this.minZoom = 0.3;
+    this.scrollSensitivity = 0.0005;
     this.offset = { x: 0, y: 0 };
     this.canvases = {
       app: null,

--- a/public/src/utils/drawing.js
+++ b/public/src/utils/drawing.js
@@ -7,12 +7,14 @@ export const updateDrawing = (p5, paintProperties) => {
 
 const handleColor = (
   p5,
-  { fillColor, fillOpacity, strokeColor, strokeOpacity }
+  { fillColor, fillOpacity, strokeColor, strokeOpacity, saturation, brightness }
 ) => {
-  const stroke = p5.color(strokeColor);
+  const strokeHue = Math.floor(p5.hue(strokeColor));
+  const stroke = p5.color(`hsb(${strokeHue}, ${saturation}%, ${brightness}%)`);
   stroke.setAlpha(strokeOpacity);
 
-  const fill = p5.color(fillColor);
+  const fillHue = Math.floor(p5.hue(fillColor));
+  const fill = p5.color(`hsb(${fillHue}, ${saturation}%, ${brightness}%)`);
   fill.setAlpha(fillOpacity);
 
   p5.stroke(stroke);

--- a/public/src/utils/initUI.js
+++ b/public/src/utils/initUI.js
@@ -19,63 +19,10 @@ export const initGuiPanels = (s, thisContext) => {
   lfo3Gui.addObject(state.lfo3.gui);
 
   handleVisibleParams();
-  // handleVisibleLfoParams(1);
-  // handleVisibleLfoParams(2);
-  // handleVisibleLfoParams(3);
   // lfos must be in the DOM to set up listeners, immediately close after init
   lfo1Gui.collapse();
   lfo2Gui.collapse();
   lfo3Gui.collapse();
-};
-
-const handleVisibleLfoParams = (lfoIndex) => {
-  const colorOptions = ["saturation", "brightness"];
-  // set initial visible params
-  initLfoParams(colorOptions, lfoIndex);
-
-  const fillColorToggle = document.querySelector(
-    `#lfo${lfoIndex} .qs_content #${p.FILL_COLOR}`
-  );
-  const strokeColorToggle = document.querySelector(
-    `#lfo${lfoIndex} .qs_content #${p.STROKE_COLOR}`
-  );
-  const toggles = [fillColorToggle, strokeColorToggle];
-
-  const areColorOptionsSelected = [false, false];
-
-  // add listeners to update visibility based on user changes
-  toggles.forEach((toggle, idx) => {
-    toggle.addEventListener("change", (e) => {
-      const isOn = e.target.checked;
-      areColorOptionsSelected[idx] = isOn;
-
-      // if either of the color-based options are selected, show the saturation/brightness sliders
-      if (areColorOptionsSelected.some((x) => x)) {
-        colorOptions.forEach((option) => {
-          const element = document.querySelector(
-            `#lfo${lfoIndex} .qs_content #${option}`
-          );
-          element.style.display = "block";
-        });
-      } else {
-        colorOptions.forEach((option) => {
-          const element = document.querySelector(
-            `#lfo${lfoIndex} .qs_content #${option}`
-          );
-          element.style.display = "none";
-        });
-      }
-    });
-  });
-};
-
-const initLfoParams = (colorOptions, lfoIndex) => {
-  colorOptions.forEach((option) => {
-    const element = document.querySelector(
-      `#lfo${lfoIndex} .qs_content #${option}`
-    );
-    element.style.display = "none";
-  });
 };
 
 const handleVisibleParams = () => {

--- a/public/src/utils/initUI.js
+++ b/public/src/utils/initUI.js
@@ -19,9 +19,9 @@ export const initGuiPanels = (s, thisContext) => {
   lfo3Gui.addObject(state.lfo3.gui);
 
   handleVisibleParams();
-  handleVisibleLfoParams(1);
-  handleVisibleLfoParams(2);
-  handleVisibleLfoParams(3);
+  // handleVisibleLfoParams(1);
+  // handleVisibleLfoParams(2);
+  // handleVisibleLfoParams(3);
   // lfos must be in the DOM to set up listeners, immediately close after init
   lfo1Gui.collapse();
   lfo2Gui.collapse();

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -4,19 +4,13 @@ import { Camera } from "./Camera.js";
 
 const cache = {};
 
-const getLfoTargetInput = (target) => {
+const getLfoTargetDOMNode = (target, inputOrLabel) => {
   if (!cache[target]) {
-    cache[target] = document.querySelector(`#${target} input`);
+    cache[target] = document.querySelector(`#${target} ${inputOrLabel}`);
     return cache[target];
   } else return cache[target];
 };
 
-const getLfoTargetLabel = (target) => {
-  if (!cache[target]) {
-    cache[target] = document.querySelector(`#${target} label`);
-    return cache[target];
-  } else return cache[target];
-};
 export const setupPaintProperties = (p5, state, zoomAmount) => {
   const { gui } = state;
   const lfo1 = useLfo(p5, state.gui, state.lfo1);
@@ -129,7 +123,7 @@ export const useLfo = (p5, gui, lfo) => {
 
     values[p.SATURATION] = scaledValue;
 
-    const input = getLfoTargetInput(p.SATURATION);
+    const input = getLfoTargetDOMNode(p.SATURATION, "input");
     input.value = scaledValue;
   }
 
@@ -140,7 +134,7 @@ export const useLfo = (p5, gui, lfo) => {
 
     values[p.BRIGHTNESS] = scaledValue;
 
-    const input = getLfoTargetInput(p.BRIGHTNESS);
+    const input = getLfoTargetDOMNode(p.BRIGHTNESS, "input");
     input.value = scaledValue;
   }
 
@@ -167,7 +161,7 @@ export const useLfo = (p5, gui, lfo) => {
 
     values[p.FILL_OPACITY] = scaledValue;
 
-    const input = getLfoTargetInput(p.FILL_OPACITY);
+    const input = getLfoTargetDOMNode(p.FILL_OPACITY, "input");
     input.value = scaledValue;
   }
 
@@ -177,7 +171,7 @@ export const useLfo = (p5, gui, lfo) => {
     const rainbow = useRainbow(p5, lfoValue);
     values[p.FILL_COLOR] = rainbow;
 
-    const label = getLfoTargetLabel(p.FILL_COLOR);
+    const label = getLfoTargetDOMNode(p.FILL_COLOR, "label");
     label.style.backgroundColor = rainbow;
   }
 
@@ -189,7 +183,7 @@ export const useLfo = (p5, gui, lfo) => {
 
     values[p.STROKE_OPACITY] = scaledValue;
 
-    const input = getLfoTargetInput(p.STROKE_OPACITY);
+    const input = getLfoTargetDOMNode(p.STROKE_OPACITY, "input");
     input.value = scaledValue;
   }
 
@@ -197,14 +191,14 @@ export const useLfo = (p5, gui, lfo) => {
     const lfoValue = Waveforms[shape](floor, lfo.value) * (amount * 3.6);
     const rainbow = useRainbow(p5, lfoValue);
     values[p.STROKE_COLOR] = rainbow;
-    const label = getLfoTargetLabel(p.STROKE_COLOR);
+    const label = getLfoTargetDOMNode(p.STROKE_COLOR, "label");
     label.style.backgroundColor = rainbow;
   }
 
   if (size) {
     const value = gui.size + Waveforms[shape](floor, lfo.value) * amount;
     values[p.SIZE] = value;
-    const input = getLfoTargetInput(p.SIZE);
+    const input = getLfoTargetDOMNode(p.SIZE, "input");
     input.value = value;
   }
 
@@ -212,7 +206,7 @@ export const useLfo = (p5, gui, lfo) => {
     const value =
       gui.strokeWeight + Waveforms[shape](floor, lfo.value) * amount;
     values[p.STROKE_WEIGHT] = value;
-    const input = getLfoTargetInput(p.STROKE_WEIGHT);
+    const input = getLfoTargetDOMNode(p.STROKE_WEIGHT, "input");
     input.value = value;
   }
 

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -150,7 +150,7 @@ export const useLfo = (p5, gui, lfo) => {
   if (fillColor) {
     // scale amount to 360 (degrees) for rotating through HSL colorspace
     const lfoValue = Waveforms[shape](floor, lfo.value) * (amount * 3.6);
-    const rainbow = useRainbow(p5, lfoValue, values.fillOpacity);
+    const rainbow = useRainbow(p5, lfoValue);
     values[p.FILL_COLOR] = rainbow;
   }
 
@@ -165,7 +165,7 @@ export const useLfo = (p5, gui, lfo) => {
 
   if (strokeColor) {
     const lfoValue = Waveforms[shape](floor, lfo.value) * (amount * 3.6);
-    const rainbow = useRainbow(p5, lfoValue, values.strokeOpacity);
+    const rainbow = useRainbow(p5, lfoValue);
     values[p.STROKE_COLOR] = rainbow;
   }
 
@@ -187,7 +187,7 @@ const scaleLfoValue = (p5, lfoValue, guiValue, min, max) => {
   return p5.map(lfoValue, -max + guiValue, max + guiValue, min, max);
 };
 
-const useRainbow = (p5, lfoValue, opacity) => {
+const useRainbow = (p5, lfoValue) => {
   const hue = Math.floor(lfoValue);
   // saturation & brightness will be overridden by global paintbrush setting
   return p5.color(`hsb(${hue}, 100%, 100%)`);

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -24,6 +24,8 @@ export const setupPaintProperties = (p5, state, zoomAmount) => {
     prevX: state.lastX,
     prevY: state.lastY,
     strokeWeight: handleLfoValue(p5, lfos, gui, p.STROKE_WEIGHT),
+    saturation: gui.saturation,
+    brightness: gui.brightness,
   };
 };
 
@@ -198,6 +200,8 @@ export const convertToLeanPaintProperties = (paintProperties, username) => {
     paintProperties.prevX,
     paintProperties.prevY,
     paintProperties.strokeWeight,
+    paintProperties.saturation,
+    paintProperties.brightness,
   ];
 };
 
@@ -223,5 +227,7 @@ export const convertLeanPaintPropertiesToObject = (leanPaintProperties) => {
     prevX: leanPaintProperties[11],
     prevY: leanPaintProperties[12],
     strokeWeight: leanPaintProperties[13],
+    saturation: leanPaintProperties[14],
+    brightness: leanPaintProperties[15],
   };
 };

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -24,8 +24,8 @@ export const setupPaintProperties = (p5, state, zoomAmount) => {
     prevX: state.lastX,
     prevY: state.lastY,
     strokeWeight: handleLfoValue(p5, lfos, gui, p.STROKE_WEIGHT),
-    saturation: gui.saturation,
-    brightness: gui.brightness,
+    saturation: handleLfoValue(p5, lfos, gui, p.SATURATION),
+    brightness: handleLfoValue(p5, lfos, gui, p.BRIGHTNESS),
   };
 };
 
@@ -81,6 +81,8 @@ export const useLfo = (p5, gui, lfo) => {
     x,
     y,
     strokeWeight,
+    saturation,
+    brightness,
   } = lfo.gui;
 
   // x & y don't have default values from GUI, so prepopulate w/ current mouse X/Y
@@ -98,9 +100,27 @@ export const useLfo = (p5, gui, lfo) => {
     strokeColor ||
     x ||
     y ||
-    strokeWeight
+    strokeWeight ||
+    saturation ||
+    brightness
   ) {
     lfo.value += speed;
+  }
+
+  if (saturation) {
+    const lfoValue =
+      gui.saturation + Waveforms[shape](floor, lfo.value) * amount;
+    const scaledValue = scaleLfoValue(p5, lfoValue, gui.saturation, 0, 100);
+
+    values[p.SATURATION] = scaledValue;
+  }
+
+  if (brightness) {
+    const lfoValue =
+      gui.brightness + Waveforms[shape](floor, lfo.value) * amount;
+    const scaledValue = scaleLfoValue(p5, lfoValue, gui.brightness, 0, 100);
+
+    values[p.BRIGHTNESS] = scaledValue;
   }
 
   if (x) {

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -2,6 +2,21 @@ import { Waveforms } from "./Waveforms.js";
 import { paintProperties as p } from "../constants.js";
 import { Camera } from "./Camera.js";
 
+const cache = {};
+
+const getLfoTargetInput = (target) => {
+  if (!cache[target]) {
+    cache[target] = document.querySelector(`#${target} input`);
+    return cache[target];
+  } else return cache[target];
+};
+
+const getLfoTargetLabel = (target) => {
+  if (!cache[target]) {
+    cache[target] = document.querySelector(`#${target} label`);
+    return cache[target];
+  } else return cache[target];
+};
 export const setupPaintProperties = (p5, state, zoomAmount) => {
   const { gui } = state;
   const lfo1 = useLfo(p5, state.gui, state.lfo1);
@@ -113,6 +128,9 @@ export const useLfo = (p5, gui, lfo) => {
     const scaledValue = scaleLfoValue(p5, lfoValue, gui.saturation, 0, 100);
 
     values[p.SATURATION] = scaledValue;
+
+    const input = getLfoTargetInput(p.SATURATION);
+    input.value = scaledValue;
   }
 
   if (brightness) {
@@ -121,6 +139,9 @@ export const useLfo = (p5, gui, lfo) => {
     const scaledValue = scaleLfoValue(p5, lfoValue, gui.brightness, 0, 100);
 
     values[p.BRIGHTNESS] = scaledValue;
+
+    const input = getLfoTargetInput(p.BRIGHTNESS);
+    input.value = scaledValue;
   }
 
   if (x) {
@@ -145,6 +166,9 @@ export const useLfo = (p5, gui, lfo) => {
     const scaledValue = scaleLfoValue(p5, lfoValue, gui.fillOpacity, 0, 255);
 
     values[p.FILL_OPACITY] = scaledValue;
+
+    const input = getLfoTargetInput(p.FILL_OPACITY);
+    input.value = scaledValue;
   }
 
   if (fillColor) {
@@ -152,6 +176,9 @@ export const useLfo = (p5, gui, lfo) => {
     const lfoValue = Waveforms[shape](floor, lfo.value) * (amount * 3.6);
     const rainbow = useRainbow(p5, lfoValue);
     values[p.FILL_COLOR] = rainbow;
+
+    const label = getLfoTargetLabel(p.FILL_COLOR);
+    label.style.backgroundColor = rainbow;
   }
 
   if (strokeOpacity) {
@@ -161,21 +188,32 @@ export const useLfo = (p5, gui, lfo) => {
     const scaledValue = scaleLfoValue(p5, lfoValue, gui.strokeOpacity, 0, 255);
 
     values[p.STROKE_OPACITY] = scaledValue;
+
+    const input = getLfoTargetInput(p.STROKE_OPACITY);
+    input.value = scaledValue;
   }
 
   if (strokeColor) {
     const lfoValue = Waveforms[shape](floor, lfo.value) * (amount * 3.6);
     const rainbow = useRainbow(p5, lfoValue);
     values[p.STROKE_COLOR] = rainbow;
+    const label = getLfoTargetLabel(p.STROKE_COLOR);
+    label.style.backgroundColor = rainbow;
   }
 
   if (size) {
-    values[p.SIZE] = gui.size + Waveforms[shape](floor, lfo.value) * amount;
+    const value = gui.size + Waveforms[shape](floor, lfo.value) * amount;
+    values[p.SIZE] = value;
+    const input = getLfoTargetInput(p.SIZE);
+    input.value = value;
   }
 
   if (strokeWeight) {
-    values[p.STROKE_WEIGHT] =
+    const value =
       gui.strokeWeight + Waveforms[shape](floor, lfo.value) * amount;
+    values[p.STROKE_WEIGHT] = value;
+    const input = getLfoTargetInput(p.STROKE_WEIGHT);
+    input.value = value;
   }
 
   return values;

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -150,7 +150,7 @@ export const useLfo = (p5, gui, lfo) => {
   if (fillColor) {
     // scale amount to 360 (degrees) for rotating through HSL colorspace
     const lfoValue = Waveforms[shape](floor, lfo.value) * (amount * 3.6);
-    const rainbow = useRainbow(p5, lfoValue, lfo.gui, values.fillOpacity);
+    const rainbow = useRainbow(p5, lfoValue, values.fillOpacity);
     values[p.FILL_COLOR] = rainbow;
   }
 
@@ -165,7 +165,7 @@ export const useLfo = (p5, gui, lfo) => {
 
   if (strokeColor) {
     const lfoValue = Waveforms[shape](floor, lfo.value) * (amount * 3.6);
-    const rainbow = useRainbow(p5, lfoValue, lfo.gui, values.strokeOpacity);
+    const rainbow = useRainbow(p5, lfoValue, values.strokeOpacity);
     values[p.STROKE_COLOR] = rainbow;
   }
 
@@ -187,15 +187,10 @@ const scaleLfoValue = (p5, lfoValue, guiValue, min, max) => {
   return p5.map(lfoValue, -max + guiValue, max + guiValue, min, max);
 };
 
-const useRainbow = (p5, lfoValue, lfoGui, opacity) => {
+const useRainbow = (p5, lfoValue, opacity) => {
   const hue = Math.floor(lfoValue);
-  const saturation = lfoGui.saturation;
-  const brightness = lfoGui.brightness;
-
-  const rainbow = p5.color(`hsb(${hue}, ${saturation}%, ${brightness}%)`);
-  rainbow.setAlpha(Math.ceil(opacity));
-
-  return rainbow;
+  // saturation & brightness will be overridden by global paintbrush setting
+  return p5.color(`hsb(${hue}, 100%, 100%)`);
 };
 
 /**

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -1,6 +1,7 @@
 import { Waveforms } from "./Waveforms.js";
 import { paintProperties as p } from "../constants.js";
 import { Camera } from "./Camera.js";
+import { state } from "../initialState.js";
 
 const cache = {};
 
@@ -116,53 +117,35 @@ export const useLfo = (p5, gui, lfo) => {
     lfo.value += speed;
   }
 
-  if (saturation) {
-    const lfoValue =
-      gui.saturation + Waveforms[shape](floor, lfo.value) * amount;
-    const scaledValue = scaleLfoValue(p5, lfoValue, gui.saturation, 0, 100);
-
-    values[p.SATURATION] = scaledValue;
-
-    const input = getLfoTargetDOMNode(p.SATURATION, "input");
-    input.value = scaledValue;
-  }
-
-  if (brightness) {
-    const lfoValue =
-      gui.brightness + Waveforms[shape](floor, lfo.value) * amount;
-    const scaledValue = scaleLfoValue(p5, lfoValue, gui.brightness, 0, 100);
-
-    values[p.BRIGHTNESS] = scaledValue;
-
-    const input = getLfoTargetDOMNode(p.BRIGHTNESS, "input");
-    input.value = scaledValue;
-  }
-
   if (x) {
-    const lfoValue =
-      p5.mouseX + (Waveforms[shape](floor, lfo.value) * 2 - 1) * amount;
-
-    values[p.X] = lfoValue;
+    p5.mouseX + (Waveforms[shape](floor, lfo.value) * 2 - 1) * amount;
   }
 
   if (y) {
-    const lfoValue =
+    values[p.Y] =
       p5.mouseY + (Waveforms[shape](floor, lfo.value) * 2 - 1) * amount;
+  }
 
-    values[p.Y] = lfoValue;
+  if (saturation) {
+    const lfoValue = Waveforms[shape](floor, lfo.value) * amount;
+    values[p.SATURATION] = lfoValue;
+    const input = getLfoTargetDOMNode(p.SATURATION, "input");
+    input.value = lfoValue;
+  }
+
+  if (brightness) {
+    const lfoValue = Waveforms[shape](floor, lfo.value) * amount;
+    values[p.BRIGHTNESS] = lfoValue;
+    const input = getLfoTargetDOMNode(p.BRIGHTNESS, "input");
+    input.value = lfoValue;
   }
 
   if (fillOpacity) {
     // scale color values by 2.55x: 100 * 2.55 = 255
-    const lfoValue =
-      gui.fillOpacity + Waveforms[shape](floor, lfo.value) * (amount * 2.55);
-
-    const scaledValue = scaleLfoValue(p5, lfoValue, gui.fillOpacity, 0, 255);
-
-    values[p.FILL_OPACITY] = scaledValue;
-
+    const lfoValue = Waveforms[shape](floor, lfo.value) * (amount * 2.55);
+    values[p.FILL_OPACITY] = lfoValue;
     const input = getLfoTargetDOMNode(p.FILL_OPACITY, "input");
-    input.value = scaledValue;
+    input.value = lfoValue;
   }
 
   if (fillColor) {
@@ -170,21 +153,15 @@ export const useLfo = (p5, gui, lfo) => {
     const lfoValue = Waveforms[shape](floor, lfo.value) * (amount * 3.6);
     const rainbow = useRainbow(p5, lfoValue);
     values[p.FILL_COLOR] = rainbow;
-
     const label = getLfoTargetDOMNode(p.FILL_COLOR, "label");
     label.style.backgroundColor = rainbow;
   }
 
   if (strokeOpacity) {
-    const lfoValue =
-      gui.strokeOpacity + Waveforms[shape](floor, lfo.value) * (amount * 2.55);
-
-    const scaledValue = scaleLfoValue(p5, lfoValue, gui.strokeOpacity, 0, 255);
-
-    values[p.STROKE_OPACITY] = scaledValue;
-
+    const lfoValue = Waveforms[shape](floor, lfo.value) * (amount * 2.55);
+    values[p.STROKE_OPACITY] = lfoValue;
     const input = getLfoTargetDOMNode(p.STROKE_OPACITY, "input");
-    input.value = scaledValue;
+    input.value = lfoValue;
   }
 
   if (strokeColor) {
@@ -196,27 +173,22 @@ export const useLfo = (p5, gui, lfo) => {
   }
 
   if (size) {
-    const value = gui.size + Waveforms[shape](floor, lfo.value) * amount;
+    const value =
+      Waveforms[shape](floor, lfo.value) *
+      ((amount * state.gui.sizeMax) / amount);
     values[p.SIZE] = value;
     const input = getLfoTargetDOMNode(p.SIZE, "input");
     input.value = value;
   }
 
   if (strokeWeight) {
-    const value =
-      gui.strokeWeight + Waveforms[shape](floor, lfo.value) * amount;
+    const value = Waveforms[shape](floor, lfo.value) * amount;
     values[p.STROKE_WEIGHT] = value;
     const input = getLfoTargetDOMNode(p.STROKE_WEIGHT, "input");
     input.value = value;
   }
 
   return values;
-};
-
-// this function handles bias/offset from GUI-derived values applied to the LFO
-// note: this function does not work w/ colors, just raw numbers
-const scaleLfoValue = (p5, lfoValue, guiValue, min, max) => {
-  return p5.map(lfoValue, -max + guiValue, max + guiValue, min, max);
 };
 
 const useRainbow = (p5, lfoValue) => {


### PR DESCRIPTION
This PR makes the following changes:
- adds paint-on-click behavior to enable drawing single points (prev. only on _drag_)
- visually show effect of LFO on brush params
- add saturation/brightness as global brush params and make them LFO target-able
- remove saturation/brightness as conditional LFO param
- fix LFO ranges and tweak LFO behavior (see 59d81d4)
- incr. camera zoom resolution, `minZoom` amount