### PR TITLE
post-demo fixes

### DIFF
--- a/public/src/app.js
+++ b/public/src/app.js
@@ -20,7 +20,7 @@ import { Loader } from "./components/loader.js";
 
 const app = (s) => {
   const keysPressed = new KeyManager(s);
-  let socket, canvas, font;
+  let socket, canvas, font, timeout;
 
   s.preload = () => {
     Loader.show();
@@ -115,17 +115,21 @@ const app = (s) => {
   };
 
   s.paint = () => {
-    s.initLastCoords();
-    const paintProperties = setupPaintProperties(s, state, camera.zoomAmount);
-    updateDrawing(s, paintProperties);
-    socket.emit(
-      EVENTS.DRAW_UPDATE,
-      convertToLeanPaintProperties(
-        paintProperties,
-        LocalStorage.get("pwf_username") || LocalStorage.get("pwf_socket")
-      )
-    );
-    s.setLastCoords();
+    if (timeout) cancelAnimationFrame(timeout);
+
+    timeout = requestAnimationFrame(() => {
+      s.initLastCoords();
+      const paintProperties = setupPaintProperties(s, state, camera.zoomAmount);
+      updateDrawing(s, paintProperties);
+      socket.emit(
+        EVENTS.DRAW_UPDATE,
+        convertToLeanPaintProperties(
+          paintProperties,
+          LocalStorage.get("pwf_username") || LocalStorage.get("pwf_socket")
+        )
+      );
+      s.setLastCoords();
+    });
   };
 
   s.mouseDragged = ({ movementX, movementY }) => {

--- a/public/src/utils/setupPaintProperties.js
+++ b/public/src/utils/setupPaintProperties.js
@@ -6,10 +6,12 @@ import { state } from "../initialState.js";
 const cache = {};
 
 const getLfoTargetDOMNode = (target, inputOrLabel) => {
-  if (!cache[target]) {
-    cache[target] = document.querySelector(`#${target} ${inputOrLabel}`);
-    return cache[target];
-  } else return cache[target];
+  const key = `#${target} ${inputOrLabel}`;
+
+  if (!cache[key]) {
+    cache[key] = document.querySelector(key);
+    return cache[key];
+  } else return cache[key];
 };
 
 export const setupPaintProperties = (p5, state, zoomAmount) => {
@@ -156,6 +158,8 @@ export const useLfo = (p5, gui, lfo) => {
     values[p.FILL_COLOR] = rainbow;
     const label = getLfoTargetDOMNode(p.FILL_COLOR, "label");
     label.style.backgroundColor = rainbow;
+    // update gui color to last value from lfo
+    gui.fillColor = rainbow;
   }
 
   if (strokeOpacity) {
@@ -171,6 +175,7 @@ export const useLfo = (p5, gui, lfo) => {
     values[p.STROKE_COLOR] = rainbow;
     const label = getLfoTargetDOMNode(p.STROKE_COLOR, "label");
     label.style.backgroundColor = rainbow;
+    gui.strokeColor = rainbow;
   }
 
   if (size) {

--- a/server.js
+++ b/server.js
@@ -63,6 +63,20 @@ app.get("/canvas", async (req, res) => {
   res.json(serializedCanvasData).status(200);
 });
 
+app.get("/image", async (req, res) => {
+  const canvasData = serializeCanvas();
+  const buffer = Buffer.from(
+    canvasData.replace(/^data:image\/png;base64,/, ""),
+    "base64"
+  );
+
+  res.writeHead(200, {
+    "Content-Type": "image/png",
+    "Content-Length": buffer.length,
+  });
+  res.end(buffer);
+});
+
 app.get("/messages", async (req, res) => {
   const messageHistory = connectedUsers.messages;
   res.json(messageHistory).status(200);


### PR DESCRIPTION
- fix brush color in UI not staying in sync w/ real value after LFO targets and un-targets colors
- throttle `paint` update rate via `requestAnimationFrame`
- add `GET /image` endpoint for fetching canvas-as-png
- improve `getLfoTargetDOMNode` helper
  - can now cache/manage multiple DOM nodes per-LFO